### PR TITLE
OSW-597: Fix throttlling.

### DIFF
--- a/python/lsst/ts/eas/dome_model.py
+++ b/python/lsst/ts/eas/dome_model.py
@@ -108,6 +108,6 @@ class DomeModel:
             return None
 
         return (
-            self.aperture_shutter_telemetry.positionActual[0] < 10
-            and self.aperture_shutter_telemetry.positionActual[1] < 10
+            self.aperture_shutter_telemetry.positionActual[0] < 50
+            and self.aperture_shutter_telemetry.positionActual[1] < 50
         )

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -22,6 +22,7 @@
 __all__ = ["EasCsc", "run_eas"]
 
 import asyncio
+import math
 import typing
 from types import SimpleNamespace
 
@@ -250,7 +251,7 @@ class EasCsc(salobj.ConfigurableCsc):
         return (
             self.weather_model.average_windspeed
             if self.weather_model is not None
-            else float("nan")
+            else math.nan
         )
 
     @staticmethod

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -222,9 +222,10 @@ class HvacModel:
                             DeviceId.lowerAHU03P05,
                             DeviceId.lowerAHU04P05,
                         ):
-                            await hvac_remote.cmd_configAhu.set_start(
+                            await hvac_remote.cmd_configLowerAhu.set_start(
                                 device_id=device_id,
+                                workingSetpoint=self.weather_model.last_twilight_temperature,
                                 maxFanSetpoint=float("nan"),
                                 minFanSetpoint=float("nan"),
-                                roomSetpoint=self.weather_model.last_twilight_temperature,
+                                antiFreezeTemperature=float("nan"),
                             )

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -23,6 +23,7 @@ __all__ = ["HvacModel", "HVAC_SLEEP_TIME"]
 
 import asyncio
 import logging
+import math
 
 from lsst.ts import salobj, utils
 from lsst.ts.xml.enums.HVAC import DeviceId
@@ -225,7 +226,7 @@ class HvacModel:
                             await hvac_remote.cmd_configLowerAhu.set_start(
                                 device_id=device_id,
                                 workingSetpoint=self.weather_model.last_twilight_temperature,
-                                maxFanSetpoint=float("nan"),
-                                minFanSetpoint=float("nan"),
-                                antiFreezeTemperature=float("nan"),
+                                maxFanSetpoint=math.nan,
+                                minFanSetpoint=math.nan,
+                                antiFreezeTemperature=math.nan,
                             )

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -23,6 +23,7 @@ __all__ = ["WeatherModel"]
 
 import asyncio
 import logging
+import math
 from collections import deque
 
 import backoff
@@ -118,7 +119,7 @@ class WeatherModel:
             NaN is returned. Units are m/s.
         """
         if not self.wind_history:
-            return float("nan")
+            return math.nan
 
         current_time = utils.current_tai()
         time_horizon = current_time - self.wind_average_window
@@ -132,7 +133,7 @@ class WeatherModel:
             not self.wind_history
             or current_time - self.wind_history[0][1] < self.wind_minimum_window
         ):
-            return float("nan")
+            return math.nan
 
         # Compute average directly
         speeds = [s for s, _ in self.wind_history]

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -2,12 +2,12 @@ wind_threshold: 5
 wind_average_window: 1800
 wind_minimum_window: 600
 vec04_hold_time: 300
-m1m3_setpoint_cadence: 10
+m1m3_setpoint_cadence: 30
 features_to_disable: []
 twilight_definition: astronomical
 weather_ess_index: 301
 indoor_ess_index: 112
-ess_timeout: 20
+ess_timeout: 40
 glycol_setpoint_delta: -2
 heater_setpoint_delta: -1
 setpoint_deadband_heating: 1

--- a/tests/test_eas_csc.py
+++ b/tests/test_eas_csc.py
@@ -140,14 +140,16 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 self.csc.monitor_start_event.wait(), timeout=STD_TIMEOUT
             )
 
+            timestamp = 0
             if self.ess112 is not None:
                 await self.ess112.tel_temperature.set_write(
                     sensorName="",
-                    timestamp=0,
+                    timestamp=timestamp,
                     numChannels=1,
                     temperatureItem=[0] * 16,
                     location="",
                 )
+                timestamp += 1
 
     async def enable_callback(self, message: salobj.topics.BaseTopic.DataType) -> None:
         """Callback for HVAC.cmd_enableDevice."""


### PR DESCRIPTION
This patch corrects some problems that was causing the EAS CSC to use too much memory and CPU. It also changes occurences of `float("nan")` to `math.nan` and changes the dome open threshold from 10% to 50% so that opening the dome during the daily handoff does not cause the HVAC to react.

The corrections needed for the EAS performance were:
- Changing the incorrect choice of `aget` for polling the ESS temperature to `next`.
- Accumulating the sum of the temperatures rather than storing them in an array.