### PR TITLE
OSW-656: Add HVAC setpoint control for nighttime.

### DIFF
--- a/doc/news/OSW-656.feature.rst
+++ b/doc/news/OSW-656.feature.rst
@@ -1,0 +1,1 @@
+Added HVAC setpoint control for nighttime.

--- a/python/lsst/ts/eas/diurnal_timer.py
+++ b/python/lsst/ts/eas/diurnal_timer.py
@@ -59,7 +59,7 @@ def get_local_noon_time() -> Time:
 
     Returns
     -------
-    Time
+    `~astropy.time.Time`
         The next occurrence of local noon in observatory time zone.
     """
 
@@ -118,7 +118,7 @@ def get_crossing_time(target_alt: float, going_up: bool = False) -> Time:
 
     Returns
     -------
-    Time
+    `~astropy.time.Time`
         The time when the sun will next cross target_alt.
     """
 
@@ -288,12 +288,12 @@ class DiurnalTimer:
 
         Parameters
         ----------
-        time : Time
+        time : `~astropy.time.Time`
             The time from which to calculate the time until twilight.
 
         Raises
         ------
-        ValueError
+        `ValueError`
             If the time calculated is negative, or is greater than
             (a little more than) one day.
         """
@@ -310,7 +310,7 @@ class DiurnalTimer:
 
         Parameters
         ----------
-        time : Time
+        time : `~astropy.time.Time`
             The time to use in the determination.
 
         Returns

--- a/python/lsst/ts/eas/dome_model.py
+++ b/python/lsst/ts/eas/dome_model.py
@@ -35,11 +35,11 @@ class DomeModel:
 
     Tracks whether and when the dome has been opened.
 
-    Paramters
+    Parameters
     ---------
-    domain : salobj.Domain
+    domain : `~lsst.ts.salobj.Domain`
         A SAL domain object for obtaining remotes.
-    log : logging.Logger
+    log : `~logging.Logger`
         A logger for log messages.
 
     """
@@ -67,7 +67,7 @@ class DomeModel:
 
         Parameters
         ----------
-        aperture_shutter_telemetry: salobj.BaseMsgType
+        aperture_shutter_telemetry: `~lsst.ts.salobj.BaseMsgType`
             A newly received apertureShutter telemetry item.
         """
         self.aperture_shutter_telemetry = aperture_shutter_telemetry

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -58,14 +58,14 @@ class EasCsc(salobj.ConfigurableCsc):
 
     Parameters
     ----------
-    config_dir : `string`
+    config_dir : str
         The configuration directory
-    initial_state : `salobj.State`
+    initial_state : `~lsst.ts.salobj.State`
         The initial state of the CSC
-    simulation_mode : `int`
+    simulation_mode : int
         Simulation mode (1) or not (0)
-    override : `str`, optional
-        Override of settings if ``initial_state`` is `State.DISABLED`
+    override : str, optional
+        Override of settings if `initial_state` is `State.DISABLED`
         or `State.ENABLED`.
     """
 

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -192,7 +192,7 @@ class EasCsc(salobj.ConfigurableCsc):
         self.log.debug("monitor_health")
 
         while self.disabled_or_enabled:
-            self.diurnal_timer.start()
+            await self.diurnal_timer.start()
 
             self.subtasks = [
                 asyncio.create_task(coro())

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -42,15 +42,15 @@ class HvacModel:
 
     Parameters
     ----------
-    domain : salobj.Domain
+    domain : `~lsst.ts.salobj.Domain`
         A SAL domain object for obtaining remotes.
-    log : logging.Logger
+    log : `~logging.Logger`
         A logger for log messages.
-    diurnal_timer : DiurnalTimer
+    diurnal_timer : `DiurnalTimer`
         A timer that signals at noon and at the end of evening twilight.
-    dome_model : DomeModel
+    dome_model : `DomeModel`
         A model representing the dome state.
-    weather_model : WeatherModel
+    weather_model : `WeatherModel`
         A model representing weather conditions.
     setpoint_lower_limit : float
         The minimum allowed setpoint for thermal control. If a lower setpoint
@@ -221,7 +221,7 @@ class HvacModel:
 
         Parameters
         ----------
-        hvac_remote : salobj.Remote
+        hvac_remote : `~lsst.ts.salobj.Remote`
             A SALobj remote representing the HVAC.
         """
         while self.diurnal_timer.is_running:
@@ -264,7 +264,7 @@ class HvacModel:
 
         Parameters
         ----------
-        hvac_remote : salobj.Remote
+        hvac_remote : `~lsst.ts.salobj.Remote`
             A SALobj remote representing the HVAC.
         """
         warned_no_temperature = False

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -44,16 +44,16 @@ class TmaModel:
 
     Parameters
     ----------
-    domain : salobj.Domain
+    domain : `~lsst.ts.salobj.Domain`
         A SAL domain object for obtaining remotes.
-    log : logging.Logger
+    log : `~logging.Logger`
         A logger for log messages.
-    diurnal_timer : DiurnalTimer
+    diurnal_timer : `DiurnalTimer`
         A timer that signals every day at noon and at the end of evening
         twilight.
-    dome_model : DomeModel
+    dome_model : `DomeModel`
         A model for the MTDome remote, indicating whether it is closed.
-    weather_model : WeatherModel
+    weather_model : `WeatherModel`
         A model for the outdoor weather station, which records the last
         twilight temperature observed while the dome was opened.
     indoor_ess_index : int
@@ -249,7 +249,7 @@ class TmaModel:
 
         Parameters
         ----------
-        mtmount_remote: salobj.Remote
+        mtmount_remote: `~lsst.ts.salobj.Remote`
             The remote object for MTMount CSC commands.
 
         setpoint: float
@@ -287,7 +287,7 @@ class TmaModel:
 
         Parameters
         ----------
-        mtmount_remote: salobj.Remote
+        mtmount_remote: `~lsst.ts.salobj.Remote`
             The remote object for MTMount CSC commands.
 
         setpoint: float
@@ -316,12 +316,12 @@ class TmaModel:
         """Gather temperature samples over the configured cadence period.
 
         If a single `asyncio.TimeoutError` occurs, the contiguous-time clock is
-        restarted (``end_time = now + cadence``).  Any other exception is
+        restarted (`end_time = now + cadence`).  Any other exception is
         propagated so that the caller can decide how to handle it.
 
         Parameters
         ----------
-        ess_remote : salobj.Remote
+        ess_remote : `~lsst.ts.salobj.Remote`
             A remote endpoint for the ESS to collect from.
 
         Returns
@@ -332,10 +332,10 @@ class TmaModel:
 
         Raises
         ------
-        asyncio.CancelledError
+        `asyncio.CancelledError`
             Propagated immediately so outer tasks can shut down cleanly.
-        Exception
-            Anything other than ``asyncio.TimeoutError`` bubbles up to the
+        `Exception`
+            Anything other than `asyncio.TimeoutError` bubbles up to the
             caller.
         """
         sum_temperatures = 0
@@ -513,9 +513,9 @@ class TmaModel:
 
         Parameters
         ----------
-        m1m3ts_remote : salobj.Remote
+        m1m3ts_remote : `~lsst.ts.salobj.Remote`
             A SALobj remote representing the MTM1M3TS controller.
-        mtmount_remote : salobj.Remote
+        mtmount_remote : `~lsst.ts.salobj.Remote`
             A SALobj remote representing the MTMount controller.
         """
         while self.diurnal_timer.is_running:

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -24,6 +24,7 @@ __all__ = ["WeatherModel"]
 import asyncio
 import logging
 import math
+import statistics
 from collections import deque
 
 import backoff
@@ -76,6 +77,9 @@ class WeatherModel:
         # A deque containing tuples of timestamp, windspeed
         self.wind_history: deque = deque()
 
+        # A deque containing tuples of timestamp, temperature
+        self.temperature_history: deque = deque(maxlen=20)
+
         # The last observed temperature at the end of twilight
         self.last_twilight_temperature: float | None = None
 
@@ -91,9 +95,6 @@ class WeatherModel:
         air_flow : salobj.BaseMsgType
            A newly received air_flow telemetry item.
         """
-        self.log.debug(
-            f"air_flow_callback: {air_flow.private_sndStamp=} sec; {air_flow.speed=} m/s"
-        )
         now = air_flow.private_sndStamp
         self.wind_history.append((air_flow.speed, now))
 
@@ -101,6 +102,19 @@ class WeatherModel:
         time_horizon = now - self.wind_average_window
         while self.wind_history and self.wind_history[0][1] < time_horizon:
             self.wind_history.popleft()
+
+    async def temperature_callback(self, temperature: salobj.BaseMsgType) -> None:
+        """Callback for ESS.tel_temperature.
+
+        This function appends new temperature data to the existing table.
+
+        Parameters
+        ----------
+        temperature : salobj.BaseMsgType
+           A newly received temperature telemetry item.
+        """
+        now = temperature.private_sndStamp
+        self.temperature_history.append((temperature.temperatureItem[0], now))
 
     @property
     def average_windspeed(self) -> float:
@@ -139,6 +153,29 @@ class WeatherModel:
         speeds = [s for s, _ in self.wind_history]
         return sum(speeds) / len(speeds)
 
+    @property
+    def current_temperature(self) -> float:
+        """Current temperature in °C.
+
+        Returns
+        -------
+        float
+            The average of the last 10 temperature samples from
+            the ESS, or NaN if there are no temperature samples
+            in the last 5 minutes.
+        """
+        cutoff = utils.current_tai() - 5 * 60
+        recent_samples = [
+            temperature
+            for temperature, time in self.temperature_history
+            if time >= cutoff
+        ]
+
+        if not recent_samples:
+            return math.nan
+
+        return statistics.median(recent_samples)
+
     async def monitor(self) -> None:
         """Monitors the dome status and windspeed to control the HVAC.
 
@@ -155,6 +192,7 @@ class WeatherModel:
             include=("airFlow", "temperature"),
         ) as weather_remote:
             weather_remote.tel_airFlow.callback = self.air_flow_callback
+            weather_remote.tel_temperature.callback = self.temperature_callback
 
             while self.diurnal_timer.is_running:
                 async with self.diurnal_timer.twilight_condition:
@@ -190,14 +228,7 @@ class WeatherModel:
     async def measure_twilight_temperature(
         self, weather_remote: salobj.Remote
     ) -> float:
-        # Collect ten temperature samples from ESS.
-        data = [
-            await weather_remote.tel_temperature.next(flush=True, timeout=SAL_TIMEOUT)
-            for _ in range(N_TWILIGHT_SAMPLES)
-        ]
-        temperature_list = [x for d in data for x in d.temperatureItem[: d.numChannels]]
-
-        # Store the average for future use.
-        last_twilight_temperature = sum(temperature_list) / len(temperature_list)
+        # Store the current temperature for future use.
+        last_twilight_temperature = self.current_temperature
         self.log.info(f"Collected twilight temperature: {last_twilight_temperature}°C")
         return last_twilight_temperature

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -43,9 +43,9 @@ class WeatherModel:
 
     Parameters
     ----------
-    domain : salobj.Domain
+    domain : `~lsst.ts.salobj.Domain`
         A SAL domain object for obtaining remotes.
-    log : logging.Logger
+    log : `~logging.Logger`
         A logger for log messages.
     wind_average_window : float
         Time over which to average windspeed for threshold determination. (s)
@@ -92,7 +92,7 @@ class WeatherModel:
 
         Parameters
         ----------
-        air_flow : salobj.BaseMsgType
+        air_flow : `~lsst.ts.salobj.BaseMsgType`
            A newly received air_flow telemetry item.
         """
         now = air_flow.private_sndStamp
@@ -110,7 +110,7 @@ class WeatherModel:
 
         Parameters
         ----------
-        temperature : salobj.BaseMsgType
+        temperature : `~lsst.ts.salobj.BaseMsgType`
            A newly received temperature telemetry item.
         """
         now = temperature.private_sndStamp


### PR DESCRIPTION
Two changes to meet the needs for this feature:
- The weather model is changed to provide current temperature. Temperature is collected by a callback now.
- The HVAC model has an additional subtask to monitor temperature and set the HVAC setpoints accordingly.