### PR TITLE
OSW-568: Use EFD for twilight temperature.

### DIFF
--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     $schema: http://json-schema.org/draft-07/schema#
     $id: https://github.com/lsst-ts/ts_eas/blob/main/python/lsst/ts/eas/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
-    title: EAS v7
+    title: EAS v8
     description: Schema for EAS configuration files
     type: object
     properties:
@@ -128,6 +128,10 @@ CONFIG_SCHEMA = yaml.safe_load(
           The minimum allowed setpoint for thermal control. If a lower setpoint
           than this is indicated from the ESS temperature readings, this setpoint
           will be used instead.
+      efd_name:
+         description: Name of the EFD instance telemetry should be queried from.
+         type: string
+
     required:
       - wind_threshold
       - wind_average_window
@@ -148,6 +152,7 @@ CONFIG_SCHEMA = yaml.safe_load(
       - slow_cooling_rate
       - fast_cooling_rate
       - setpoint_lower_limit
+      - efd_name
     additionalProperties: false
     """
 )

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -141,7 +141,7 @@ class EasCsc(salobj.ConfigurableCsc):
             domain=self.domain,
             log=self.log,
             diurnal_timer=self.diurnal_timer,
-            dome_model=self.dome_model,
+            efd_name=self.config.efd_name,
             ess_index=self.config.weather_ess_index,
             wind_average_window=self.config.wind_average_window,
             wind_minimum_window=self.config.wind_minimum_window,

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -229,14 +229,17 @@ class HvacModel:
                 self.monitor_start_event.set()
 
                 await self.diurnal_timer.noon_condition.wait()
+                last_twilight_temperature = (
+                    await self.weather_model.get_last_twilight_temperature()
+                )
                 if (
                     self.diurnal_timer.is_running
-                    and self.weather_model.last_twilight_temperature is not None
+                    and last_twilight_temperature is not None
                 ):
                     if "room_setpoint" not in self.features_to_disable:
                         # Time to set the room setpoint based on last twilight
                         setpoint = max(
-                            self.weather_model.last_twilight_temperature,
+                            last_twilight_temperature,
                             self.setpoint_lower_limit,
                         )
 

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -17,3 +17,4 @@ maximum_heating_rate: 0.2
 slow_cooling_rate: 1
 fast_cooling_rate: 10
 setpoint_lower_limit: 6
+efd_name: test

--- a/tests/test_weather_model.py
+++ b/tests/test_weather_model.py
@@ -1,0 +1,167 @@
+# This file is part of ts_eas.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+import math
+import unittest
+from unittest import mock
+
+import pandas as pd
+from astropy.time import Time
+from lsst.ts import eas, salobj, utils
+
+STD_TIMEOUT = 10
+
+
+class MockDiurnalTimer:
+    is_running = True
+    twilight_condition = asyncio.Condition()
+
+    def get_twilight_time(self, of_date: Time) -> Time:
+        return Time("2025-01-01T00:00:00")  # Not important
+
+
+class TestGetLastTwilightTemperature(
+    salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase
+):
+    async def asyncSetUp(self) -> None:
+        """Constructs a WeatherModel object for testing."""
+        log = logging.getLogger()
+        self.domain = salobj.Domain()
+        self.ess = salobj.Controller("ESS", 301)
+        self.diurnal_timer = MockDiurnalTimer()
+        await self.ess.start_task
+
+        self.weather_model = eas.weather_model.WeatherModel(
+            domain=self.domain,
+            log=log,
+            diurnal_timer=self.diurnal_timer,
+            efd_name="mocked",
+        )
+        await super().asyncSetUp()
+
+    async def asyncTearDown(self) -> None:
+        await self.ess.close()
+        await self.domain.close()
+
+        await super().asyncTearDown()
+
+    async def test_returns_cached_value_when_present(self) -> None:
+        """The model should not use EFD if a value is cached."""
+        self.weather_model.last_twilight_temperature = 7.0
+        with mock.patch("lsst_efd_client.EfdClient") as EfdClient:
+            result = await self.weather_model.get_last_twilight_temperature()
+        self.assertEqual(result, 7.0)
+        EfdClient.assert_not_called()
+
+    async def test_fetches_and_returns_median_temperature(self) -> None:
+        """The model should use the median of all samples returned from EFD."""
+        # First day: empty -> forces loop to continue
+        # Second day: valid data -> median should be 8.0
+        df_empty = pd.DataFrame(columns=["temperatureItem0"])
+        df_valid = pd.DataFrame({"temperatureItem0": [7.0, 8.0, 9.0]})
+
+        mock_client = mock.MagicMock()
+        mock_client.select_time_series = mock.AsyncMock(
+            side_effect=[
+                df_empty,  # day 1
+                df_valid,  # day 2
+            ]
+        )
+
+        with mock.patch(
+            "lsst_efd_client.EfdClient", return_value=mock_client
+        ) as EfdClient:
+            result = await self.weather_model.get_last_twilight_temperature()
+
+        self.assertEqual(result, 8.0)
+        # Confirm cache populated
+        self.assertEqual(self.weather_model.last_twilight_temperature, 8.0)
+        # Confirm EfdClient was constructed only once.
+        self.assertGreaterEqual(EfdClient.call_count, 1)
+        # Check select_time_series called with expected args on the second call
+        args_list = mock_client.select_time_series.call_args_list
+        self.assertEqual(args_list[1].args[0], "lsst.sal.ESS.temperature")
+        self.assertEqual(args_list[1].args[1], ["temperatureItem0"])
+        self.assertEqual(args_list[1].kwargs["index"], self.weather_model.ess_index)
+
+    async def test_returns_none_when_all_days_missing_or_nan(self) -> None:
+        """The model should return None if EFD data are missing or invalid.
+
+        The "NaN" scenario is not expected but it doesn't hurt anything to
+        be prepared for the possibility.
+        """
+        # Mix of empty frames and frames whose median is NaN
+        df_empty = pd.DataFrame(columns=["temperatureItem0"])
+        df_nan = pd.DataFrame({"temperatureItem0": [math.nan, math.nan]})
+        side_effect = [df_empty, df_nan] * 5  # 10 array elements for 10 days of history
+
+        mock_client = mock.MagicMock()
+        mock_client.select_time_series = mock.AsyncMock(side_effect=side_effect)
+
+        with mock.patch("lsst_efd_client.EfdClient", return_value=mock_client):
+            result = await self.weather_model.get_last_twilight_temperature()
+
+        self.assertIsNone(result)
+        self.assertIsNone(self.weather_model.last_twilight_temperature)
+
+    async def test_temperature_updated(self) -> None:
+        """At twilight, the last twilight_temperature should be updated."""
+
+        monitor_task = asyncio.create_task(self.weather_model.monitor())
+        await asyncio.wait_for(
+            self.weather_model.monitor_start_event.wait(), timeout=STD_TIMEOUT
+        )
+
+        await self.ess.tel_temperature.set_write(
+            sensorName="",
+            timestamp=utils.current_tai(),
+            numChannels=1,
+            temperatureItem=[12.0] + [0.0] * 15,
+            location="",
+        )
+
+        await asyncio.sleep(1)  # Give the telemetry time to get through
+        async with self.diurnal_timer.twilight_condition:
+            self.diurnal_timer.twilight_condition.notify_all()
+
+        # Pass control to the event loop so that the condition can notify:
+        await asyncio.sleep(0)
+
+        with mock.patch("lsst_efd_client.EfdClient") as EfdClient:
+            result = await self.weather_model.get_last_twilight_temperature()
+        self.assertEqual(result, 12.0)
+        EfdClient.assert_not_called()
+
+        monitor_task.cancel()
+        try:
+            await monitor_task
+        except asyncio.CancelledError:
+            pass
+
+    def basic_make_csc(
+        self,
+        initial_state: None,
+        config_dir: None,
+        simulation_mode: int,
+    ) -> salobj.BaseCsc:
+        raise NotImplementedError("Not actually using basic_make_csc for anything.")


### PR DESCRIPTION
This change to EAS transitions from reading twilight temperature strictly from telemetry to using the EFD. This ensures that a twilight temperature measurement is available, even if the EAS CSC was not running at twilight.

- Code is added to DiurnalTimer to provide the time of twilight to external classes. This is used by WeatherModel.
- WeatherModel sets the twilight temperature, if none is available, using the EFD. It continues to use CSC telemetry to obtain twilight temperature measurements going forward, so the only EFD query happens at CSC enable.
- There is also some cleanup work in the tests, that I hope will alleviate the problem with Kafka topics hanging around.

This PR also incorporates OSW-813, in which Brian asks that the twilight temperature determination remove the condition that the dome must be open to collect a valid measurement.