### PR TITLE
OSW-860: control glycol chiller 1/2 setpoints with EAS

### DIFF
--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     $id: https://github.com/lsst-ts/ts_eas/blob/main/python/lsst/ts/eas/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
     title: EAS v9
-    description: Schema for EAS configuration files
+    description: Schema for EAS configuration files.
     type: object
     properties:
       weather:
@@ -42,14 +42,28 @@ CONFIG_SCHEMA = yaml.safe_load(
         description: TMA configuration items.
         type: object
       features_to_disable:
-        description: List of CSC control points to disable
+        description: >-
+          List of EAS functionalities to disable. Options are:
+            * `room_setpoint`: HVAC setpoints will not be applied.
+            * `ahu`: HVAC AHUs will not be enabled / disabled.
+            * `vec04`: VEC-04 exhaust fan will not be enabled / disabled.
+            * `fanspeed`: MTM1M3TS fans will not be controlled.
+            * `m1m3ts`: MTM1M3TS setpoints will not be applied.
+            * `require_dome_open`: functionality will operate even when the dome is closed.
         type: array
         items:
           type: string
+          enum:
+            - room_setpoint
+            - ahu
+            - vec04
+            - fanspeed
+            - m1m3ts
+            - require_dome_open
       twilight_definition:
         description: >
           Definition of twilight. Can be a number (in degrees) between -90 and 0, corresponding
-          to sun elevation, or one of the strings: "civil", "nautical", "astronomical"
+          to sun elevation, or one of the strings: "civil", "nautical", "astronomical".
         oneOf:
           - type: number
             minimum: -90

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -28,33 +28,19 @@ CONFIG_SCHEMA = yaml.safe_load(
     $schema: http://json-schema.org/draft-07/schema#
     $id: https://github.com/lsst-ts/ts_eas/blob/main/python/lsst/ts/eas/config_schema.py
     # title must end with one or more spaces followed by the schema version, which must begin with "v"
-    title: EAS v8
+    title: EAS v9
     description: Schema for EAS configuration files
     type: object
     properties:
-      wind_threshold:
-        description: Windspeed limit for the VEC-04 fan (m/s)
-        type: number
-        exclusiveMinimum: 0
-      wind_average_window:
-        description: Time over which to average windspeed for threshold determination (s)
-        type: number
-        exclusiveMinimum: 0
-      wind_minimum_window:
-        description: Minimum amount of time to collect wind data before acting on it. (s)
-        type: number
-        exclusiveMinimum: 0
-      vec04_hold_time:
-        description: >
-          Minimum time to wait before changing the state of the VEC-04 fan. This
-          value is ignored if the dome is opened or closed. (s)
-        type: number
-        exclusiveMinimum: 0
-      m1m3_setpoint_cadence:
-        description: >
-          Frequency at which to send commands to MTM1M3TS to change the setpoint. (s)
-        type: number
-        exclusiveMinimum: 0
+      weather:
+        description: Weather configuration items.
+        type: object
+      hvac:
+        description: HVAC configuration items.
+        type: object
+      tma:
+        description: TMA configuration items.
+        type: object
       features_to_disable:
         description: List of CSC control points to disable
         type: array
@@ -70,89 +56,13 @@ CONFIG_SCHEMA = yaml.safe_load(
             maximum: 0
           - type: string
             enum: ["civil", "nautical", "astronomical"]
-      weather_ess_index:
-        description: SAL index for the CSC providing weather information
-        type: integer
-        minimum: 0
-      indoor_ess_index:
-        description: SAL index for the CSC providing indoor temperature measurements.
-        type: integer
-        minimum: 0
-      ess_timeout:
-        description: >
-          The amount of time (seconds) of no ESS measurements after which
-          the CSC should fault.
-        type: number
-      glycol_setpoint_delta:
-        description: >
-          Offset between desired ambient setpoint and M1M3TS glycol setpoint (°C)
-        type: number
-      heater_setpoint_delta:
-        description: >
-          Offset between desired ambient setpoint and MTM3TS FCU heater setpoint (°C)
-        type: number
-      top_end_setpoint_delta:
-        description: >
-          Offset between measured indoor temperature and the top end setpoint (°C)
-        type: number
-      setpoint_deadband_heating:
-        description: >
-          Deadband for M1M3TS heating. If the the new setpoint exceeds the previous
-          setpoint by less than this amount, no new command is sent. (°C)
-      setpoint_deadband_cooling:
-        description: >
-          Deadband for M1M3TS cooling. If the new setpoint is lower than the previous
-          setpoint by less than this amount, no new command is sent. (°C)
-        type: number
-        minimum: 0
-      maximum_heating_rate:
-        description: >
-          Maximum allowed rate of increase in the M1M3TS setpoint temperature. Limits
-          how quickly the setpoint can rise, in degrees Celsius per hour. (°C/hr)
-        type: number
-        minimum: 0
-      slow_cooling_rate:
-        description: >
-          Cooling rate to be used shortly before and during the night.
-          Limits how quickly the setpoint can fall, in degrees Celsius per hour.
-        type: number
-        minimum: 0
-      fast_cooling_rate:
-        description: >
-          Cooling rate to be used during the day. Limits how quickly the setpoint
-          can fall, in degrees Celsius per hour.
-        type: number
-        minimum: 0
-      setpoint_lower_limit:
-        description: >
-          The minimum allowed setpoint for thermal control. If a lower setpoint
-          than this is indicated from the ESS temperature readings, this setpoint
-          will be used instead.
-      efd_name:
-         description: Name of the EFD instance telemetry should be queried from.
-         type: string
 
     required:
-      - wind_threshold
-      - wind_average_window
-      - wind_minimum_window
-      - vec04_hold_time
-      - m1m3_setpoint_cadence
+      - weather
+      - hvac
+      - tma
       - features_to_disable
       - twilight_definition
-      - weather_ess_index
-      - indoor_ess_index
-      - ess_timeout
-      - glycol_setpoint_delta
-      - heater_setpoint_delta
-      - top_end_setpoint_delta
-      - setpoint_deadband_heating
-      - setpoint_deadband_cooling
-      - maximum_heating_rate
-      - slow_cooling_rate
-      - fast_cooling_rate
-      - setpoint_lower_limit
-      - efd_name
     additionalProperties: false
     """
 )

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -66,8 +66,8 @@ CONFIG_SCHEMA = yaml.safe_load(
           to sun elevation, or one of the strings: "civil", "nautical", "astronomical".
         oneOf:
           - type: number
-            minimum: -90
-            maximum: 0
+            minimum: -90.0
+            maximum: 0.0
           - type: string
             enum: ["civil", "nautical", "astronomical"]
 

--- a/python/lsst/ts/eas/diurnal_timer.py
+++ b/python/lsst/ts/eas/diurnal_timer.py
@@ -366,6 +366,19 @@ class DiurnalTimer:
         """
         return get_crossing_time(self.sun_altitude, going_up=False, search_from=after)
 
+    def get_sunrise_time(self, after: Time) -> Time:
+        """Return the time of next end of twilight for the given time.
+
+        Parameters
+        ----------
+        after : `~astropy.time.Time`
+            Time returned will be time corresponding to the
+            end of twilight on or after this time.
+        """
+        return get_crossing_time(
+            SOLAR_ELEVATION_AT_SUNSET, going_up=True, search_from=after
+        )
+
     def sun_altitude_at(self, t_utc: float) -> float:
         """Return the sun altitude in degrees at the specified time.
 

--- a/python/lsst/ts/eas/diurnal_timer.py
+++ b/python/lsst/ts/eas/diurnal_timer.py
@@ -46,11 +46,20 @@ OBSERVATORY_TIME_ZONE = ZoneInfo("America/Santiago")
 # Standard definition of sunrise / sunset with solar elevation -0.833 degrees.
 SOLAR_ELEVATION_AT_SUNSET = -0.833
 
+HOURS_PER_DAY = 24
+SECONDS_PER_HOUR = 3600
+
+CIVIL_TWILIGHT = -6.0
+NAUTICAL_TWILIGHT = -12.0
+ASTRONOMICAL_TWILIGHT = -18.0
+
+TIME_EPSILON = 1 * u.s  # A small increment of time
+
 
 def get_local_noon_time() -> Time:
-    """Returns the next local noon as an astropy.time.Time object.
+    """Return the next local noon as an astropy.time.Time object.
 
-    If the current time is past local noon today, returns noon tomorrow.
+    If the current time is past local noon today, return noon tomorrow.
     The difference from noon to noon is 24 hours except when there's
     a time change because of daylight saving time.
 
@@ -61,7 +70,7 @@ def get_local_noon_time() -> Time:
     """
 
     now = Time.now()
-    now += 1 * u.min
+    now += TIME_EPSILON
 
     # Convert current time to local datetime with correct DST info
     local_now = now.to_datetime(timezone=OBSERVATORY_TIME_ZONE)
@@ -85,7 +94,7 @@ def get_local_noon_time() -> Time:
 
 
 def get_sun_altitude_deg(t: Time) -> float:
-    """Returns the sun's altitude at the given time.
+    """Return the sun's altitude at the given time.
 
     The altitude is based on the specified observatory
     location and does not account for atmospheric
@@ -97,24 +106,26 @@ def get_sun_altitude_deg(t: Time) -> float:
         The sun's altitude (deg) above the horizon at time t.
     """
     sun = get_sun(t)
-    altaz = sun.transform_to(AltAz(obstime=t, location=OBSERVATORY_LOCATION))
+    altaz = sun.transform_to(
+        AltAz(obstime=t, location=OBSERVATORY_LOCATION, pressure=0)
+    )
     return altaz.alt.deg
 
 
 def get_crossing_time(
     target_alt: float, going_up: bool = False, search_from: Time | None = None
 ) -> Time:
-    """Computes the time when the sun will reach target_alt.
+    """Compute the time when the sun will reach target_alt.
 
     Parameters
     ----------
-    target_alt : float
+    target_alt : `float`
         The sun altitude at the twilight time to search for, in degrees.
     search_from : `~astropy.time.Time` | None
         The time to start searching from. The returned value will be
         the first instance of the sun crossing the target altitude
         after this time.
-    going_up : bool
+    going_up : `bool`
         True if searching for the crossing of the target altitude
         while the sun altitude is increasing ("sun is rising"),
         of False if the sun should be decreasing in altitude at the
@@ -132,11 +143,15 @@ def get_crossing_time(
 
     # Start by searching for a good window for the root finder.
     if search_from is None:
-        search_from = Time.now() + 1 * u.min
-    t0 = search_from + 1 * u.s
+        search_from = Time.now()
+    t0 = search_from + TIME_EPSILON
     sun_altitude_before = get_sun_altitude_deg(t0)
-    for i in range(25):  # Start by searching the next 25 hours.
-        t1 = t0 + 1 * u.hour
+
+    # Start by searching the next 25 hours. The time between sunrises, sunsets,
+    # twilights can be more than 24 hours when days are getting longer, but
+    # (at least for Cerro Pachón) will never be more than 25 hours.
+    search_range = HOURS_PER_DAY + 1
+    for t1 in [t0 + i * u.hour for i in range(search_range + 1)]:
         sun_altitude_after = get_sun_altitude_deg(t1)
 
         if going_up:
@@ -148,11 +163,9 @@ def get_crossing_time(
 
         # Nope, keep looking
         sun_altitude_before = sun_altitude_after
-        t0 = t1
 
-    t0 = t0.unix
     t1 = t1.unix
-
+    t0 = t1 - SECONDS_PER_HOUR
     t_cross = brentq(f, t0, t1)
     return Time(t_cross, format="unix")
 
@@ -162,20 +175,20 @@ class DiurnalTimer:
 
     Parameters
     ----------
-    sun_altitude : str | float
+    sun_altitude : `str` | `float`
         The sun altitude (degrees) below the horizon that is considered the
         end of twilight. This can be a number between 0 and -90 or it can
         be one of "civil" (-6 degrees), "nautical" (-12 degrees), or
         "astronomical"(-18 degrees).
     """
 
-    def __init__(self, sun_altitude: str | float = -18.0):
+    def __init__(self, sun_altitude: str | float = NAUTICAL_TWILIGHT):
         if sun_altitude == "civil":
-            sun_altitude = -6.0
+            sun_altitude = CIVIL_TWILIGHT
         elif sun_altitude == "nautical":
-            sun_altitude = -12.0
+            sun_altitude = NAUTICAL_TWILIGHT
         elif sun_altitude == "astronomical":
-            sun_altitude = -18.0
+            sun_altitude = ASTRONOMICAL_TWILIGHT
         elif isinstance(sun_altitude, str):
             raise RuntimeError(
                 "Allowed string values for "
@@ -384,7 +397,7 @@ class DiurnalTimer:
 
         Parameters
         ----------
-        t_utc : float
+        t_utc : `float`
             The time of interest to look up sun altitude, specified
             in UTC seconds in the UNIX epoch.
 
@@ -416,7 +429,7 @@ class DiurnalTimer:
             )
 
         t = (self.twilight_time - time).sec
-        if t < 0 or t > 25 * 3600:
+        if t < 0 or t > (HOURS_PER_DAY + 1) * SECONDS_PER_HOUR:
             raise ValueError(f"Time until twilight unexpectedly out of range: {t}")
         return t
 
@@ -440,12 +453,12 @@ class DiurnalTimer:
             )
 
         t = (self.sunrise_time - time).sec
-        if t < 0 or t > 25 * 3600:
+        if t < 0 or t > (HOURS_PER_DAY + 1) * SECONDS_PER_HOUR:
             raise ValueError(f"Time until sunrise unexpectedly out of range: {t}")
         return t
 
     def is_night(self, time: Time) -> bool:
-        """Returns True if `time` is in the EAS-defined night.
+        """Return True if `time` is in the EAS-defined night.
 
         If the time is after twilight and before sunrise, it is
         considered to be night.

--- a/python/lsst/ts/eas/dome_model.py
+++ b/python/lsst/ts/eas/dome_model.py
@@ -28,12 +28,13 @@ from lsst.ts import salobj, utils
 
 DORMANT_TIME = 300  # Time to wait while sleeping, seconds
 MAX_TELEMETRY_AGE = 300  # Time at which apertureShutter telemetry expires, seconds
+DOME_OPEN_THRESHOLD = 50  # Dome open percentage at which the dome is considered "open"
 
 
 class DomeModel:
     """A model for MTDome.
 
-    Tracks whether and when the dome has been opened.
+    Track whether and when the dome has been opened.
 
     Parameters
     ---------
@@ -95,7 +96,7 @@ class DomeModel:
 
     @property
     def is_closed(self) -> bool | None:
-        """Returns true if the dome is currently closed.
+        """Return true if the dome is currently closed.
 
         If the current state of the dome is unknown, None is returned.
         """
@@ -108,6 +109,6 @@ class DomeModel:
             return None
 
         return (
-            self.aperture_shutter_telemetry.positionActual[0] < 50
-            and self.aperture_shutter_telemetry.positionActual[1] < 50
+            self.aperture_shutter_telemetry.positionActual[0] < DOME_OPEN_THRESHOLD
+            and self.aperture_shutter_telemetry.positionActual[1] < DOME_OPEN_THRESHOLD
         )

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -59,13 +59,13 @@ class EasCsc(salobj.ConfigurableCsc):
 
     Parameters
     ----------
-    config_dir : str
+    config_dir : `str`
         The configuration directory
     initial_state : `~lsst.ts.salobj.State`
         The initial state of the CSC
-    simulation_mode : int
+    simulation_mode : `int`
         Simulation mode (1) or not (0)
-    override : str, optional
+    override : `str`, optional
         Override of settings if `initial_state` is `State.DISABLED`
         or `State.ENABLED`.
     """
@@ -114,7 +114,7 @@ class EasCsc(salobj.ConfigurableCsc):
             await self.shutdown_health_monitor()
 
     async def shutdown_health_monitor(self) -> None:
-        """Cancels the health monitor task and waits for completion."""
+        """Cancel the health monitor task and waits for completion."""
         tasks_to_cancel = self.subtasks
         self.subtasks = []
         tasks_to_cancel.append(self.health_monitor_task)
@@ -180,9 +180,9 @@ class EasCsc(salobj.ConfigurableCsc):
         )
 
     async def monitor_health(self) -> None:
-        """Manages the `monitor_dome_shutter` control loop.
+        """Manage the `monitor_dome_shutter` control loop.
 
-        Manages the `monitor_dome_shutter` control loop with backoff and
+        Manage the `monitor_dome_shutter` control loop with backoff and
         time-based failure reset, which is (hopefully) robust against
         disconnects of the remotes, as well as any other form of
         recoverable failure.

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -148,6 +148,7 @@ class EasCsc(salobj.ConfigurableCsc):
             diurnal_timer=self.diurnal_timer,
             efd_name=self.config.efd_name,
             ess_index=self.config.weather_ess_index,
+            indoor_ess_index=self.config.indor_ess_index,
             wind_average_window=self.config.wind_average_window,
             wind_minimum_window=self.config.wind_minimum_window,
         )

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -142,15 +142,22 @@ class EasCsc(salobj.ConfigurableCsc):
             domain=self.domain,
             log=self.log,
         )
+
+        # Validate the sub-schemas and update with defaults.
+        for object_type, attr in (
+            (WeatherModel, "weather"),
+            (HvacModel, "hvac"),
+            (TmaModel, "tma"),
+        ):
+            schema = object_type.get_config_schema()
+            validator = salobj.DefaultingValidator(schema)
+            setattr(config, attr, validator.validate(getattr(config, attr)))
+
         self.weather_model = WeatherModel(
             domain=self.domain,
             log=self.log,
             diurnal_timer=self.diurnal_timer,
-            efd_name=self.config.efd_name,
-            ess_index=self.config.weather_ess_index,
-            indoor_ess_index=self.config.indor_ess_index,
-            wind_average_window=self.config.wind_average_window,
-            wind_minimum_window=self.config.wind_minimum_window,
+            **self.config.weather,
         )
         self.hvac_model = HvacModel(
             domain=self.domain,
@@ -158,10 +165,8 @@ class EasCsc(salobj.ConfigurableCsc):
             diurnal_timer=self.diurnal_timer,
             dome_model=self.dome_model,
             weather_model=self.weather_model,
-            setpoint_lower_limit=self.config.setpoint_lower_limit,
-            wind_threshold=self.config.wind_threshold,
-            vec04_hold_time=self.config.vec04_hold_time,
             features_to_disable=self.config.features_to_disable,
+            **self.config.hvac,
         )
         self.tma_model = TmaModel(
             domain=self.domain,
@@ -170,18 +175,8 @@ class EasCsc(salobj.ConfigurableCsc):
             dome_model=self.dome_model,
             glass_temperature_model=self.glass_temperature_model,
             weather_model=self.weather_model,
-            indoor_ess_index=self.config.indoor_ess_index,
-            ess_timeout=self.config.ess_timeout,
-            glycol_setpoint_delta=self.config.glycol_setpoint_delta,
-            heater_setpoint_delta=self.config.heater_setpoint_delta,
-            top_end_setpoint_delta=self.config.top_end_setpoint_delta,
-            m1m3_setpoint_cadence=self.config.m1m3_setpoint_cadence,
-            setpoint_deadband_heating=self.config.setpoint_deadband_heating,
-            setpoint_deadband_cooling=self.config.setpoint_deadband_cooling,
-            maximum_heating_rate=self.config.maximum_heating_rate,
-            slow_cooling_rate=self.config.slow_cooling_rate,
-            fast_cooling_rate=self.config.fast_cooling_rate,
             features_to_disable=self.config.features_to_disable,
+            **self.config.tma,
         )
 
     async def monitor_health(self) -> None:

--- a/python/lsst/ts/eas/glass_temperature_model.py
+++ b/python/lsst/ts/eas/glass_temperature_model.py
@@ -124,7 +124,7 @@ class GlassTemperatureModel:
 
     @property
     def median_temperature(self) -> float | None:
-        """Computes median glass temperature.
+        """Compute median glass temperature.
 
         This getter finds all temperature samples
         that are less than 5 minutes old, and
@@ -155,10 +155,10 @@ class GlassTemperatureModel:
         return statistics.median(valid_temperatures)
 
     async def monitor(self) -> None:
-        """Starts the monitor for this model.
+        """Start the monitor for this model.
 
-        Connects to the four thermal scanner ESS controllers,
-        sets up callbacks, and idles.
+        Connect to the four thermal scanner ESS controllers,
+        set up callbacks, and idle.
         """
         self.log.debug("GlassTemperatureModel.monitor")
 

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -152,13 +152,13 @@ properties:
   wind_threshold:
     type: number
     default: 10
-    description: Windspeed limit for the VEC-04 fan. (m/s)
+    description: Windspeed limit for the VEC-04 fan (m/s).
   vec04_hold_time:
     type: number
     default: 300
     description: >-
       Minimum time to wait before changing the state of the VEC-04 fan. This
-      value is ignored if the dome is opened or closed. (s)
+      value is ignored if the dome is opened or closed (s).
   glycol_band_low:
     type: number
     default: -10

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -32,7 +32,6 @@ import asyncio
 import logging
 import math
 import time
-import yaml
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Callable
@@ -319,10 +318,12 @@ additionalProperties: false
         m1m3ts_remote: salobj.Remote,
         setpoint: float,
     ) -> None:
-        if "m1m3ts" in self.features_to_disable:
+        if "m1m3ts" not in self.features_to_disable:
             glycol_setpoint = setpoint + self.glycol_setpoint_delta
             heaters_setpoint = setpoint + self.heater_setpoint_delta
-            self.log.info(f"Setting MTM1MTS: {glycol_setpoint=}°C {heaters_setpoint=}°C")
+            self.log.info(
+                f"Setting MTM1MTS: {glycol_setpoint=}°C {heaters_setpoint=}°C"
+            )
             await m1m3ts_remote.cmd_applySetpoints.set_start(
                 glycolSetpoint=glycol_setpoint,
                 heatersSetpoint=heaters_setpoint,
@@ -530,9 +531,7 @@ additionalProperties: false
             use_slow_cooling_rate = (
                 (not self.dome_model.is_closed)
                 or (self.diurnal_timer.sun_altitude_at(current_time) < 0)
-                or (
-                    self.diurnal_timer.seconds_until_twilight(Time.now()) < 2 * 3600
-                )
+                or (self.diurnal_timer.seconds_until_twilight(Time.now()) < 2 * 3600)
             )
             cooling_rate = (
                 self.slow_cooling_rate
@@ -549,10 +548,7 @@ additionalProperties: false
             elif indoor_temperature > last_m1m3ts_setpoint:
                 # Warm the mirror if the setpoint is past the deadband
                 new_setpoint = indoor_temperature
-                if (
-                    new_setpoint - last_m1m3ts_setpoint
-                    > self.setpoint_deadband_heating
-                ):
+                if new_setpoint - last_m1m3ts_setpoint > self.setpoint_deadband_heating:
                     # Apply the setpoint, limited by maximum_heating_rate
                     maximum_heating_step = (
                         self.maximum_heating_rate * self.m1m3_setpoint_cadence / 3600.0
@@ -587,10 +583,7 @@ additionalProperties: false
             else:
                 # Cool the mirror if the setpoint is past the deadband
                 new_setpoint = indoor_temperature
-                if (
-                    last_m1m3ts_setpoint - new_setpoint
-                    > self.setpoint_deadband_cooling
-                ):
+                if last_m1m3ts_setpoint - new_setpoint > self.setpoint_deadband_cooling:
                     # Apply the setpoint, limited by maximum_cooling_rate
                     maximum_cooling_step = (
                         cooling_rate * self.m1m3_setpoint_cadence / 3600.0

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -37,6 +37,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Callable
 
+import yaml
 from astropy.time import Time
 from lsst.ts import salobj, utils
 from lsst.ts.xml.enums.MTMount import ThermalCommandState

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -207,30 +207,43 @@ description: Schema for TMA EAS configuration.
 type: object
 properties:
   glycol_setpoint_delta:
+    description: Difference (°C) between the ambient temperature and M1M3TS glycol setpoint.
     type: number
     default: -2
   heater_setpoint_delta:
+    description: Difference (°C) between the ambient temperature and M1M3TS heater setpoint.
     type: number
     default: -1
   top_end_setpoint_delta:
+    description: Difference (°C) between the ambient temperature and MTMount thermal setpoint.
     type: number
     default: -1
   m1m3_setpoint_cadence:
+    description: Time (s) between successive assessments of the TMA setpoint.
     type: number
     default: 300
   setpoint_deadband_heating:
+    description: Allowed upward deviation (°C) of MTM1M3TS setpoint before it is re-applied.
     type: number
     default: 0.1
   setpoint_deadband_cooling:
+    description: Allowed downward deviation (°C) of MTM1M3TS setpoint before it is re-applied.
     type: number
     default: 0.1
   maximum_heating_rate:
+    description: Maximum allowed rate (°C/hour) at which the MTM1M3 setpoint is allowed to increase.
     type: number
     default: 1.0
   slow_cooling_rate:
+    description: >-
+        Maximum allowed rate (°C/hour) at which the MTM1M3 setpoint is allowed to decrease
+        while observing.
     type: number
     default: 1.0
   fast_cooling_rate:
+    description: >-
+        Maximum allowed rate (°C/hour) at which the MTM1M3 setpoint is allowed to decrease
+        while observing.
     type: number
     default: 10.0
 required:

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -125,18 +125,25 @@ description: Schema for EAS weather configuration.
 type: object
 properties:
   efd_name:
+    description: The name of the EFD deployment to use.
     type: string
     default: test
   ess_index:
+    description: The SAL index to use for outdoor weather information.
     type: integer
     default: 301
   indoor_ess_index:
+    description: The SAL index to use for indoor weather information.
     type: integer
     default: 112
   wind_average_window:
+    description: Time window (s) of past windspeed telemetry to use in calculating an average.
     type: number
     default: 1800
   wind_minimum_window:
+    description: >-
+      Minimum required baseline time (s) of past windspeed data needed to calculate a reliable
+      average. If this baseline is not available, the VEC-04 fan will be turned off.
     type: number
     default: 600
 required:

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -29,6 +29,7 @@ from collections import deque
 
 import astropy.units as u
 import lsst_efd_client
+import yaml
 from astropy.time import Time
 from lsst.ts import salobj, utils
 
@@ -97,14 +98,14 @@ class WeatherModel:
         # The last observed temperature at the end of twilight
         self.last_twilight_temperature: float | None = None
 
-        # True if the next valid dewpoint sample represents
+        # True if the next valid dew point sample represents
         # the beginning of the night.
-        self.need_to_reset_dewpoint = True
+        self.need_to_reset_dew_point = True
 
-        # Maximum reported dewpoint temperature (°C)
+        # Maximum reported dew point temperature (°C)
         # for last night (if it is daytime) or the current
         # night (if it is nighttime).
-        self.nightly_maximum_indoor_dewpoint: float | None = None
+        self.nightly_maximum_indoor_dew_point: float | None = None
 
         # True if the next valid temperature sample represents
         # the beginning of the night.
@@ -324,19 +325,19 @@ additionalProperties: false
 
         Parameters
         ----------
-        dewpoint : `~lsst.ts.salobj.BaseMsgType`
-           A newly received dewpoint telemetry item.
+        dew_point : `~lsst.ts.salobj.BaseMsgType`
+           A newly received dew point telemetry item.
         """
         if self.diurnal_timer.is_night(Time.now()):
-            if self.need_to_reset_dewpoint:
-                self.nightly_maximum_indoor_dewpoint = dewpoint.dewpointItem
-                self.need_to_reset_dewpoint = False
+            if self.need_to_reset_dew_point:
+                self.nightly_maximum_indoor_dew_point = dew_point.dewPointItem
+                self.need_to_reset_dew_point = False
             else:
-                self.nightly_maximum_indoor_dewpoint = max(
-                    dewpoint.dewpointItem, self.nightly_maximum_indoor_dewpoint
+                self.nightly_maximum_indoor_dew_point = max(
+                    dew_point.dewpointItem, self.nightly_maximum_indoor_dew_point
                 )
         else:
-            self.need_to_reset_dewpoint = True
+            self.need_to_reset_dew_point = True
 
     @property
     def average_windspeed(self) -> float:

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -22,7 +22,7 @@ tma:
   setpoint_deadband_heating: 0.05
   setpoint_deadband_cooling: 0.05
   maximum_heating_rate: 1.0
-  slow_cooling_rate: 1.00
+  slow_cooling_rate: 1.0
   fast_cooling_rate: 10.0
 features_to_disable: []
 twilight_definition: astronomical

--- a/tests/config/_init.yaml
+++ b/tests/config/_init.yaml
@@ -1,20 +1,28 @@
-wind_threshold: 5
-wind_average_window: 1800
-wind_minimum_window: 600
-vec04_hold_time: 300
-m1m3_setpoint_cadence: 30
+weather:
+  efd_name: test
+  ess_index: 301
+  indoor_ess_index: 112
+  wind_average_window: 1800
+  wind_minimum_window: 600
+hvac:
+  setpoint_lower_limit: 6
+  wind_threshold: 10
+  vec04_hold_time: 300
+  glycol_band_low: -10.0
+  glycol_band_high: -5.0
+  glycol_average_offset: -7.5
+  glycol_dew_point_margin: 1.0
+  glycol_setpoints_delta: 1.0
+  glycol_absolute_minimum: -10.0
+tma:
+  glycol_setpoint_delta: -2.0
+  heater_setpoint_delta: -1.0
+  top_end_setpoint_delta: -1.0
+  m1m3_setpoint_cadence: 30
+  setpoint_deadband_heating: 0.05
+  setpoint_deadband_cooling: 0.05
+  maximum_heating_rate: 1.0
+  slow_cooling_rate: 1.00
+  fast_cooling_rate: 10.0
 features_to_disable: []
 twilight_definition: astronomical
-weather_ess_index: 301
-indoor_ess_index: 112
-ess_timeout: 40
-glycol_setpoint_delta: -2
-heater_setpoint_delta: -1
-top_end_setpoint_delta: -1
-setpoint_deadband_heating: 1
-setpoint_deadband_cooling: 0.5
-maximum_heating_rate: 0.2
-slow_cooling_rate: 1
-fast_cooling_rate: 10
-setpoint_lower_limit: 6
-efd_name: test

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -1,0 +1,670 @@
+# This file is part of ts_eas.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+import math
+import unittest
+from typing import TypedDict
+
+import astropy
+from lsst.ts import salobj
+from lsst.ts.eas import hvac_model
+from lsst.ts.xml.enums.HVAC import DeviceId
+
+STD_TIMEOUT = 10
+STD_SLEEP = 2
+
+
+class WeatherModelMock:
+    def __init__(
+        self,
+        *,
+        last_twilight_temperature: float | None = None,
+        average_windspeed: float | None = None,
+        current_temperature: float | None = None,
+        current_indoor_temperature: float | None = None,
+        nightly_minimum_temperature: float | None = None,
+        nightly_maximum_indoor_dew_point: float | None = None,
+    ) -> None:
+        self.last_twilight_temperature = last_twilight_temperature
+        self.average_windspeed = average_windspeed
+        self.current_temperature = current_temperature
+        self.current_indoor_temperature = current_indoor_temperature
+        self.nightly_minimum_temperature = nightly_minimum_temperature
+        self.nightly_maximum_indoor_dew_point = nightly_maximum_indoor_dew_point
+
+    async def get_last_twilight_temperature(self) -> float | None:
+        return self.last_twilight_temperature
+
+
+class DomeModelMock:
+    def __init__(self, is_closed: bool | None = None) -> None:
+        self.is_closed = is_closed
+
+
+class DiurnalTimerMock:
+    def __init__(self, *, running: bool = True, night: bool = False) -> None:
+        self.is_running = running
+        self._night = night
+        self.noon_condition = asyncio.Condition()
+        self.sunrise_condition = asyncio.Condition()
+
+    def is_night(self, time: astropy.time.Time) -> bool:
+        return self._night
+
+    async def stop(self) -> None:
+        self.is_running = False
+        async with self.noon_condition:
+            self.noon_condition.notify_all()
+        async with self.sunrise_condition:
+            self.sunrise_condition.notify_all()
+
+
+async def signal_noon(timer: DiurnalTimerMock) -> None:
+    async def signal_coroutine() -> None:
+        await asyncio.sleep(STD_SLEEP)
+        async with timer.noon_condition:
+            timer.noon_condition.notify_all()
+        await asyncio.sleep(STD_SLEEP)
+        await timer.stop()
+
+    await asyncio.wait_for(
+        asyncio.create_task(signal_coroutine()),
+        timeout=STD_TIMEOUT,
+    )
+
+
+async def signal_sunrise(timer: DiurnalTimerMock) -> None:
+    async def signal_coroutine() -> None:
+        await asyncio.sleep(STD_SLEEP)
+        async with timer.sunrise_condition:
+            timer.sunrise_condition.notify_all()
+        await asyncio.sleep(STD_SLEEP)
+        await timer.stop()
+
+    await asyncio.wait_for(
+        asyncio.create_task(signal_coroutine()),
+        timeout=STD_TIMEOUT,
+    )
+
+
+class HvacMock(salobj.BaseCsc):
+    version = "?"
+
+    def __init__(self) -> None:
+        self.valid_simulation_modes = (0,)
+        super().__init__(
+            name="HVAC",
+            index=None,
+            initial_state=salobj.State.ENABLED,
+            allow_missing_callbacks=True,
+        )
+        self.enable_called: set[int] = set()
+        self.disable_called: set[int] = set()
+        self.chiller_setpoints: dict[int, float] = dict()  # Calls to configChiller
+        self.ahu_setpoints: dict[int, float] = dict()  # Calls to configLowerAhu
+
+    async def do_enableDevice(self, data: salobj.BaseMsgType) -> None:
+        self.enable_called.add(data.device_id)
+
+    async def do_disableDevice(self, data: salobj.BaseMsgType) -> None:
+        self.disable_called.add(data.device_id)
+
+    async def do_configLowerAhu(self, data: salobj.BaseMsgType) -> None:
+        self.ahu_setpoints[data.device_id] = data.workingSetpoint
+
+    async def do_configChiller(self, data: salobj.BaseMsgType) -> None:
+        self.chiller_setpoints[data.device_id] = data.activeSetpoint
+
+
+class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+
+        self.log = logging.getLogger("hvac")
+        self.hvac = HvacMock()
+        await self.hvac.start_task
+
+        self.remote = salobj.Remote(name="HVAC", domain=self.hvac.domain)
+        await self.remote.start_task
+
+        self.diurnal = DiurnalTimerMock(running=True, night=False)
+        self.dome = DomeModelMock(is_closed=True)
+        self.weather = WeatherModelMock(
+            last_twilight_temperature=8.0,
+            average_windspeed=3.0,
+            current_temperature=7.5,
+            current_indoor_temperature=15.0,
+            nightly_minimum_temperature=6.0,
+            nightly_maximum_indoor_dew_point=-10.0,
+        )
+
+    def make_model(self, **overrides: float | list[str] | None) -> hvac_model.HvacModel:
+        params = dict(
+            setpoint_lower_limit=6.0,
+            wind_threshold=10.0,
+            vec04_hold_time=0.0,
+            glycol_band_low=-10.0,
+            glycol_band_high=-5.0,
+            glycol_average_offset=-7.5,
+            glycol_dew_point_margin=1.0,
+            glycol_setpoints_delta=1.0,
+            glycol_absolute_minimum=-10.0,
+            features_to_disable=[],
+        )
+        params.update(overrides)
+
+        return hvac_model.HvacModel(
+            domain=self.hvac.domain,
+            log=self.log,
+            diurnal_timer=self.diurnal,
+            dome_model=self.dome,
+            weather_model=self.weather,
+            **params,
+        )
+
+    async def asyncTearDown(self) -> None:
+        try:
+            await self.remote.close()
+            await self.hvac.close()
+        finally:
+            await super().asyncTearDown()
+
+    # --- GLYCOL CHILLER TESTS --- #
+
+    def test_average_and_delta(self) -> None:
+        """Basic test that average and delta match the stated requirement."""
+        model = self.make_model()
+        s1, s2 = model.compute_glycol_setpoints(self.weather.current_indoor_temperature)
+
+        expected_avg = (
+            self.weather.current_indoor_temperature + model.glycol_average_offset
+        )  # 15 - 7.5 = 7.5
+
+        # Average of the two setpoints should differ from the ambient
+        # by `glycol_average_offset`.
+        self.assertAlmostEqual((s1 + s2) / 2.0, expected_avg, places=6)
+
+        # The two setpoints should differ by `glycol_setpoints_delta`
+        self.assertAlmostEqual(s1 - s2, model.glycol_setpoints_delta, places=6)
+
+        # Chiller 1 setpoint should be the warmer.
+        self.assertGreater(s1, s2)
+
+        # Average is inside the prescribed band
+        band_low = self.weather.current_indoor_temperature + model.glycol_band_low
+        band_high = self.weather.current_indoor_temperature + model.glycol_band_high
+        self.assertTrue(band_low <= expected_avg <= band_high)
+
+    def test_dew_point_guard_raises_average(self) -> None:
+        """If nighttime dewpoint is high, raise setpoint average."""
+        self.weather.nightly_maximum_indoor_dew_point = 9.0
+        model = self.make_model()  # margin default = 1.0
+
+        # Nominal average would be 7.5, but dew point 9 + margin 1 = 10
+        #   --> average raised to 10.
+        s1, s2 = model.compute_glycol_setpoints(self.weather.current_indoor_temperature)
+        self.assertAlmostEqual((s1 + s2) / 2.0, 10.0, places=6)
+
+    def test_average_inside_band_returns_true(self) -> None:
+        """Average offset within [band_low, band_high] should be True."""
+        model = self.make_model()
+        # Choose setpoints around the nominal average 7.5 with delta=1.0
+        model.glycol_setpoint1 = 8.0
+        model.glycol_setpoint2 = 7.0
+
+        self.assertTrue(
+            model.check_glycol_setpoint(self.weather.current_indoor_temperature)
+        )
+
+    def test_average_below_band_returns_false(self) -> None:
+        """Test glycol average below band."""
+        model = self.make_model()
+        # Push average to 4.0 (below band_low=5.0)
+        model.glycol_setpoint1 = 4.5
+        model.glycol_setpoint2 = 3.5
+
+        self.assertFalse(
+            model.check_glycol_setpoint(self.weather.current_indoor_temperature)
+        )
+
+    def test_average_above_band_returns_false(self) -> None:
+        """Test glycol average above band."""
+        model = self.make_model()
+        # Push average to 11.0 (above band_high=10.0)
+        model.glycol_setpoint1 = 11.5
+        model.glycol_setpoint2 = 10.5
+
+        self.assertFalse(
+            model.check_glycol_setpoint(self.weather.current_indoor_temperature)
+        )
+
+    async def test_adjust_glycol_at_noon(self) -> None:
+        """Signal noon and verify that glycol setpoints are issued."""
+        model = self.make_model()
+
+        signal_task = asyncio.create_task(signal_noon(self.diurnal))
+        await model.adjust_glycol_chillers_at_noon(hvac_remote=self.remote)
+
+        await signal_task
+
+        # Verify that the applied setpoints match expectation:
+        #  * Average of the two setpoints should be
+        #    last night's minimum temperature plus the configured offset
+        #  * The two sepoints should be separated by the
+        #    configured delta.
+        setpoints = (model.glycol_setpoint1, model.glycol_setpoint2)
+        setpoint_average = sum(setpoints) / len(setpoints)
+        self.assertAlmostEqual(
+            model.glycol_setpoint1 - model.glycol_setpoint2,
+            model.glycol_setpoints_delta,
+        )
+        self.assertAlmostEqual(
+            setpoint_average,
+            self.weather.nightly_minimum_temperature + model.glycol_average_offset,
+        )
+
+        # HVAC setpoints should match model setpoints.
+        self.assertAlmostEqual(
+            self.hvac.chiller_setpoints[DeviceId.chiller01P01],
+            model.glycol_setpoint1,
+        )
+        self.assertAlmostEqual(
+            self.hvac.chiller_setpoints[DeviceId.chiller02P01],
+            model.glycol_setpoint2,
+        )
+
+    async def test_missing_nightly_minimum(self) -> None:
+        """Signal noon without a nightly minimum temperature."""
+        self.weather.nightly_minimum_temperature = None
+        model = self.make_model()
+
+        signal_task = asyncio.create_task(signal_noon(self.diurnal))
+        await model.adjust_glycol_chillers_at_noon(hvac_remote=self.remote)
+        await signal_task
+
+        self.assertEqual(len(self.hvac.chiller_setpoints), 0)
+        self.assertIsNone(model.glycol_setpoint1)
+        self.assertIsNone(model.glycol_setpoint2)
+
+    async def test_recalculate_glycol_setpoints(self) -> None:
+        """Glycol setpoints recalculate if ambient pushes them out of band."""
+        hvac_model.HVAC_SLEEP_TIME = 0.0
+        model = self.make_model()
+
+        model.glycol_setpoint1 = -10
+        model.glycol_setpoint2 = -11
+
+        signal_task = asyncio.create_task(signal_noon(self.diurnal))
+        await model.monitor_glycol_chillers(hvac_remote=self.remote)
+        await signal_task
+
+        # Setpoints should be recalculated based on
+        # `current_indoor_temperature` in the weather model.
+        average = sum(self.hvac.chiller_setpoints.values()) / len(
+            self.hvac.chiller_setpoints
+        )
+        difference = (
+            self.hvac.chiller_setpoints[DeviceId.chiller01P01]
+            - self.hvac.chiller_setpoints[DeviceId.chiller02P01]
+        )
+        self.assertAlmostEqual(difference, model.glycol_setpoints_delta)
+        self.assertAlmostEqual(
+            average,
+            self.weather.current_indoor_temperature + model.glycol_average_offset,
+        )
+
+    async def test_dont_recalculate_glycol_setpoints(self) -> None:
+        """Glycol setpoints don't recalculate if they remain in band."""
+        hvac_model.HVAC_SLEEP_TIME = 0.0
+        model = self.make_model()
+
+        initial_setpoint1 = 9
+        initial_setpoint2 = 8
+        model.glycol_setpoint1 = initial_setpoint1
+        model.glycol_setpoint2 = initial_setpoint2
+
+        signal_task = asyncio.create_task(signal_noon(self.diurnal))
+        await model.monitor_glycol_chillers(hvac_remote=self.remote)
+        await signal_task
+
+        # Setpoints should NOT be recalculated
+        self.assertAlmostEqual(
+            self.hvac.chiller_setpoints[DeviceId.chiller01P01],
+            initial_setpoint1,
+        )
+        self.assertAlmostEqual(
+            self.hvac.chiller_setpoints[DeviceId.chiller02P01],
+            initial_setpoint2,
+        )
+
+    # --- LOWER AHU TESTS --- #
+
+    # control_ahus_and_vec04
+    async def test_dome_open_and_calm_wind(self) -> None:
+        # Dome open and calm winds
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0  # below threshold 10.0
+
+        model = self.make_model()
+        task = asyncio.create_task(
+            model.control_ahus_and_vec04(hvac_remote=self.remote)
+        )
+
+        await asyncio.sleep(STD_SLEEP)  # Allow enough time for 5 SAL commands.
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        # VEC-04 was enabled
+        self.assertIn(DeviceId.lowerDamperFan03P04, self.hvac.enable_called)
+        self.assertNotIn(DeviceId.lowerDamperFan03P04, self.hvac.disable_called)
+
+        for ahu in (
+            DeviceId.lowerAHU01P05,
+            DeviceId.lowerAHU02P05,
+            DeviceId.lowerAHU03P05,
+            DeviceId.lowerAHU04P05,
+        ):
+            # All 4 AHUs should have been disabled when dome opened
+            self.assertIn(ahu, self.hvac.disable_called)
+
+            # And none should have been enabled
+            self.assertNotIn(ahu, self.hvac.enable_called)
+
+    async def test_vec04_turns_off(self) -> None:
+        # Start open and calm so VEC-04 enables first
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0
+
+        model = self.make_model()
+        task = asyncio.create_task(
+            model.control_ahus_and_vec04(hvac_remote=self.remote)
+        )
+
+        # Let it enable VEC-04
+        await asyncio.sleep(STD_SLEEP)
+        self.assertIn(DeviceId.lowerDamperFan03P04, self.hvac.enable_called)
+        self.assertNotIn(DeviceId.lowerDamperFan03P04, self.hvac.disable_called)
+
+        # Wind rises above threshold --> should disable VEC-04
+        self.weather.average_windspeed = 12.0
+        await asyncio.sleep(STD_SLEEP)
+        self.assertIn(DeviceId.lowerDamperFan03P04, self.hvac.disable_called)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+    async def test_ahus_on_shutter_close(self) -> None:
+        """If shutter closes, AHUs should enable and VEC-04 should disable."""
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0
+
+        model = self.make_model()
+        task = asyncio.create_task(
+            model.control_ahus_and_vec04(hvac_remote=self.remote)
+        )
+
+        # First iteration: VEC-04 ON
+        await asyncio.sleep(STD_SLEEP)
+
+        for ahu in (
+            DeviceId.lowerAHU01P05,
+            DeviceId.lowerAHU02P05,
+            DeviceId.lowerAHU03P05,
+            DeviceId.lowerAHU04P05,
+        ):
+            # AHUs not enabled because dome is open.
+            self.assertNotIn(ahu, self.hvac.enable_called)
+
+        # Close the shutter --> AHUs enabled, VEC-04 OFF
+        self.dome.is_closed = True
+        await asyncio.sleep(STD_SLEEP)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        # VEC-04 forced OFF on close
+        self.assertIn(DeviceId.lowerDamperFan03P04, self.hvac.disable_called)
+
+        for ahu in (
+            DeviceId.lowerAHU01P05,
+            DeviceId.lowerAHU02P05,
+            DeviceId.lowerAHU03P05,
+            DeviceId.lowerAHU04P05,
+        ):
+            # AHUs enabled on close
+            self.assertIn(ahu, self.hvac.enable_called)
+
+    async def test_vec04_disabled(self) -> None:
+        """VEC04 commands are not sent if 'vec04' in `features_to_disable`."""
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0
+
+        model = self.make_model(features_to_disable=["vec04"])
+        task = asyncio.create_task(
+            model.control_ahus_and_vec04(hvac_remote=self.remote)
+        )
+
+        await asyncio.sleep(STD_SLEEP)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        self.assertNotIn(DeviceId.lowerDamperFan03P04, self.hvac.enable_called)
+        self.assertNotIn(DeviceId.lowerDamperFan03P04, self.hvac.disable_called)
+
+    async def test_ahu_disabled(self) -> None:
+        """AHU commands are not sent if 'ahu' in `features_to_disable`."""
+        self.dome.is_closed = False
+
+        model = self.make_model(features_to_disable=["ahu"])
+        task = asyncio.create_task(
+            model.control_ahus_and_vec04(hvac_remote=self.remote)
+        )
+
+        await asyncio.sleep(STD_SLEEP)
+        self.dome.is_closed = True  # transition to open
+        await asyncio.sleep(STD_SLEEP)
+        self.dome.is_closed = True  # transition back to closed
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        for ahu in (
+            DeviceId.lowerAHU01P05,
+            DeviceId.lowerAHU02P05,
+            DeviceId.lowerAHU03P05,
+            DeviceId.lowerAHU04P05,
+        ):
+            # No commands sent to lower AHUs
+            self.assertNotIn(ahu, self.hvac.enable_called)
+            self.assertNotIn(ahu, self.hvac.disable_called)
+
+    async def test_wait_for_sunrise(self) -> None:
+        class SubtestCase(TypedDict):
+            name: str
+            last_twilight: float
+            features_to_disable: list[str]
+            expect_setpoints: dict[int, float]
+
+        cases: list[SubtestCase] = [
+            {
+                "name": "apply last-twilight setpoint",
+                "last_twilight": 10.0,
+                "features_to_disable": [],
+                "expect_setpoints": {
+                    DeviceId.lowerAHU01P05: 10.0,
+                    DeviceId.lowerAHU02P05: 10.0,
+                    DeviceId.lowerAHU03P05: 10.0,
+                    DeviceId.lowerAHU04P05: 10.0,
+                },
+            },
+            {
+                "name": "enforce lower limit",
+                "last_twilight": 4.0,
+                "features_to_disable": [],
+                "expect_setpoints": {
+                    DeviceId.lowerAHU01P05: 6.0,
+                    DeviceId.lowerAHU02P05: 6.0,
+                    DeviceId.lowerAHU03P05: 6.0,
+                    DeviceId.lowerAHU04P05: 6.0,
+                },
+            },
+            {
+                "name": "room_setpoint disabled",
+                "last_twilight": 4.0,
+                "features_to_disable": ["room_setpoint"],
+                "expect_setpoints": {},  # type: ignore[typeddict-item]
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+                self.diurnal.is_running = True
+                self.weather.last_twilight_temperature = case["last_twilight"]
+                model = self.make_model(
+                    features_to_disable=case.get("features_to_disable"),
+                )
+
+                task = asyncio.create_task(
+                    model.wait_for_sunrise(hvac_remote=self.remote)
+                )
+                await signal_sunrise(self.diurnal)
+                await asyncio.sleep(STD_SLEEP)  # let it apply
+                await self.diurnal.stop()
+
+                await asyncio.wait_for(task, timeout=STD_SLEEP)
+
+                self.assertDictEqual(self.hvac.ahu_setpoints, case["expect_setpoints"])
+
+                # Reset between subtests
+                self.hvac.ahu_setpoints.clear()
+
+    async def test_apply_setpoint_at_night(self) -> None:
+        """Test `apply_setpoint_at_night`."""
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+
+        class SubtestCase(TypedDict):
+            name: str
+            night: bool
+            closed: bool
+            temp: float
+            expect_setpoints: dict[str, float]
+
+        scenarios: list[SubtestCase] = [
+            {
+                "name": "night closed apply setpoints",
+                "night": True,
+                "closed": True,
+                "temp": 6.0,
+                "expect_setpoints": {
+                    ahu: 6.0
+                    for ahu in (
+                        DeviceId.lowerAHU01P05,
+                        DeviceId.lowerAHU02P05,
+                        DeviceId.lowerAHU03P05,
+                        DeviceId.lowerAHU04P05,
+                    )
+                },
+            },
+            {
+                "name": "night open --> no setpoints",
+                "night": True,
+                "closed": False,
+                "temp": 9.0,
+                "expect_setpoints": {},
+            },
+            {
+                "name": "day closed --> no setpoints",
+                "night": False,
+                "closed": True,
+                "temp": 12.0,
+                "expect_setpoints": {},
+            },
+            {
+                "name": "night closed NaN temp --> no setpoints",
+                "night": True,
+                "closed": True,
+                "temp": math.nan,
+                "expect_setpoints": {},
+            },
+        ]
+
+        for case in scenarios:
+            with self.subTest(case=case["name"]):
+                self.diurnal._night = case["night"]
+                self.dome.is_closed = case["closed"]
+                self.weather.current_temperature = case["temp"]
+
+                model = self.make_model()
+                task = asyncio.create_task(
+                    model.apply_setpoint_at_night(hvac_remote=self.remote)
+                )
+
+                await asyncio.sleep(STD_SLEEP)
+                await self.diurnal.stop()
+                await asyncio.wait_for(task, timeout=STD_SLEEP)
+
+                self.assertEqual(self.hvac.ahu_setpoints, case["expect_setpoints"])
+                # reset for next scenario
+                self.hvac.ahu_setpoints.clear()
+
+    def basic_make_csc(
+        self,
+        initial_state: salobj.State | int | None,
+        config_dir: str,
+        simulation_mode: int,
+    ) -> salobj.BaseCsc:
+        """Make and return a CSC.
+
+        Parameters
+        ----------
+        initial_state : `lsst.ts.salobj.State` or `int`
+            The initial state of the CSC.
+        config_dir : `str` or `pathlib.Path` or `None`
+            Directory of configuration files, or None for the standard
+            configuration directory (obtained from
+            `ConfigureCsc._get_default_config_dir`).
+        simulation_mode : `int`
+            Simulation mode.
+        """
+        raise NotImplementedError()

--- a/tests/test_m1m3ts.py
+++ b/tests/test_m1m3ts.py
@@ -153,6 +153,10 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             M1M3TSMock() as mock_m1m3ts,
             MTMountMock() as mock_mtmount,
         ):
+            await mock_mtmount.evt_summaryState.set_write(
+                summaryState=salobj.State.ENABLED
+            )
+
             self.tma_model = eas.tma_model.TmaModel(
                 domain=self.domain,
                 log=mock_m1m3ts.log,

--- a/tests/test_m1m3ts.py
+++ b/tests/test_m1m3ts.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import contextlib
 import logging
 import typing
 import unittest
@@ -83,6 +82,7 @@ class MTMountMock(salobj.BaseCsc):
 class WeatherModelMock:
     def __init__(self, last_twilight_temperature: float) -> None:
         self.last_twilight_temperature = last_twilight_temperature
+        self.current_indoor_temperature: float | None = 10
 
     async def get_last_twilight_temperature(self) -> float:
         return self.last_twilight_temperature
@@ -98,58 +98,20 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self.last_twilight_temperature = 20
         super().setUp()
 
-    @contextlib.asynccontextmanager
-    async def mock_extra_cscs(
-        self, ess112_temperature: float | None
-    ) -> typing.AsyncGenerator[None, None]:
-        self.domain = salobj.Domain()
-        self.log = logging.getLogger()
-        self.ess112 = salobj.Controller("ESS", 112)
-
-        await self.ess112.start_task
-
-        self.weather_model = WeatherModelMock(self.last_twilight_temperature)
-        self.dome_model = DomeModelMock(is_closed=False)
-
-        if ess112_temperature is not None:
-            emit_ess112_temperature_task = asyncio.create_task(
-                self.emit_ess112_temperature(ess112_temperature)
-            )
-
-        try:
-            yield
-        finally:
-            if ess112_temperature is not None:
-                emit_ess112_temperature_task.cancel()
-                try:
-                    await emit_ess112_temperature_task
-                except asyncio.CancelledError:
-                    pass
-            await self.ess112.close()
-            await self.domain.close()
-
-    async def emit_ess112_temperature(self, ess112_temperature: float) -> None:
-        while True:
-            await asyncio.sleep(3)
-            await self.ess112.tel_temperature.set_write(
-                sensorName="",
-                timestamp=0,
-                numChannels=1,
-                temperatureItem=[ess112_temperature] * 16,
-                location="",
-            )
-
     async def run_with_parameters(
         self,
-        ess112_temperature: float | None,
+        indoor_temperature: float | None = 10,
         signal_sunrise: bool = False,
         **model_args: typing.Any,
     ) -> tuple[float | None, float | None, float | None, list[float] | None]:
         self.diurnal_timer = eas.diurnal_timer.DiurnalTimer()
         self.diurnal_timer.is_running = True
 
+        self.weather_model = WeatherModelMock(self.last_twilight_temperature)
+        self.weather_model.current_indoor_temperature = indoor_temperature
+        self.dome_model = DomeModelMock(is_closed=False)
+
         async with (
-            self.mock_extra_cscs(ess112_temperature),
             M1M3TSMock() as mock_m1m3ts,
             MTMountMock() as mock_mtmount,
         ):
@@ -158,14 +120,12 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             )
 
             self.tma_model = eas.tma_model.TmaModel(
-                domain=self.domain,
+                domain=mock_m1m3ts.domain,
                 log=mock_m1m3ts.log,
                 diurnal_timer=self.diurnal_timer,
                 dome_model=self.dome_model,
                 glass_temperature_model=SimpleNamespace(median_temperature=0.0),
                 weather_model=self.weather_model,
-                indoor_ess_index=112,
-                ess_timeout=20,
                 glycol_setpoint_delta=model_args["glycol_setpoint_delta"],
                 heater_setpoint_delta=model_args["heater_setpoint_delta"],
                 top_end_setpoint_delta=model_args["top_end_setpoint_delta"],
@@ -194,9 +154,6 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             except asyncio.CancelledError:
                 pass
 
-            await mock_mtmount.close()
-            await mock_m1m3ts.close()
-
             return (
                 mock_m1m3ts.glycol_setpoint,
                 mock_m1m3ts.heater_setpoint,
@@ -206,14 +163,13 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_m1m3ts_applysetpoints(self) -> None:
         """M1M3TS.applySetpoint should be called at sunrise."""
-        ess112_temperature = 10
         glycol_setpoint_delta = -2
         heater_setpoint_delta = -1
         top_end_setpoint_delta = -0.5
 
         glycol_setpoint, heater_setpoint, top_end_setpoint, _ = (
             await self.run_with_parameters(
-                ess112_temperature,
+                indoor_temperature=10,
                 glycol_setpoint_delta=glycol_setpoint_delta,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=top_end_setpoint_delta,
@@ -242,14 +198,12 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_disabled_m1m3ts(self) -> None:
         """The applySetpoint should not be called when m1m3ts is disabled."""
-        ess112_temperature = 10
         glycol_setpoint_delta = -2
         heater_setpoint_delta = -1
         top_end_setpoint_delta = -1.5
 
         glycol_setpoint, heater_setpoint, top_end_setpoint, fan_rpm = (
             await self.run_with_parameters(
-                ess112_temperature,
                 glycol_setpoint_delta=glycol_setpoint_delta,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=top_end_setpoint_delta,
@@ -260,18 +214,20 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self.assertTrue(glycol_setpoint is None)
         self.assertTrue(heater_setpoint is None)
         self.assertTrue(top_end_setpoint is not None)
-        self.assertIsNone(fan_rpm)
+        assert fan_rpm is not None
+        expected_fan_rpm = int(0.1 * eas.tma_model.MAX_FAN_RPM)
+        self.assertAlmostEqual(fan_rpm[0], expected_fan_rpm, 3)
 
     async def test_disabled_top_end(self) -> None:
         """The applySetpoint should not be called when m1m3ts is disabled."""
-        ess112_temperature = 0.5
+        indoor_temperature = 0.5
         glycol_setpoint_delta = -2
         heater_setpoint_delta = -1
         top_end_setpoint_delta = -1
 
         glycol_setpoint, heater_setpoint, top_end_setpoint, fan_rpm = (
             await self.run_with_parameters(
-                ess112_temperature,
+                indoor_temperature=indoor_temperature,
                 glycol_setpoint_delta=glycol_setpoint_delta,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=top_end_setpoint_delta,
@@ -290,14 +246,12 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_disabled_tma(self) -> None:
         """The applySetpoint should not be called when m1m3ts is disabled."""
-        ess112_temperature = 10
         glycol_setpoint_delta = -2
         heater_setpoint_delta = -1
         top_end_setpoint_delta = -1.5
 
         glycol_setpoint, heater_setpoint, top_end_setpoint, _ = (
             await self.run_with_parameters(
-                ess112_temperature,
                 glycol_setpoint_delta=glycol_setpoint_delta,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=top_end_setpoint_delta,
@@ -311,7 +265,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_no_ess112(self) -> None:
         """tma_model.monitor() should raise if ESS112 does not send data."""
-        ess112_temperature = None
+        indoor_temperature = None
         glycol_setpoint_delta = -2
         heater_setpoint_delta = -1
         top_end_setpoint_delta = -1
@@ -319,7 +273,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError):
             glycol_setpoint, heater_setpoint, top_end_setpoint, _ = (
                 await self.run_with_parameters(
-                    ess112_temperature,
+                    indoor_temperature=indoor_temperature,
                     glycol_setpoint_delta=glycol_setpoint_delta,
                     heater_setpoint_delta=heater_setpoint_delta,
                     top_end_setpoint_delta=top_end_setpoint_delta,
@@ -337,23 +291,26 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_fan_speed(self) -> None:
         """Compare behavior with specifications in OSW-820."""
-        self.diurnal_timer = eas.diurnal_timer.DiurnalTimer()
-        self.diurnal_timer.is_running = True
+        diurnal_timer = eas.diurnal_timer.DiurnalTimer()
+        diurnal_timer.is_running = True
+
+        weather_model = WeatherModelMock(self.last_twilight_temperature)
+        weather_model.current_indoor_temperature = 10
+        dome_model = DomeModelMock(is_closed=False)
 
         async with (
-            self.mock_extra_cscs(10),
             M1M3TSMock() as mock_m1m3ts,
-            salobj.Remote(name="MTM1M3TS", domain=self.domain) as mtm1m3ts_remote,
+            salobj.Remote(
+                name="MTM1M3TS", domain=mock_m1m3ts.domain
+            ) as mtm1m3ts_remote,
         ):
             tma_model = eas.tma_model.TmaModel(
-                domain=self.domain,
+                domain=mock_m1m3ts.domain,
                 log=mock_m1m3ts.log,
-                diurnal_timer=self.diurnal_timer,
-                dome_model=self.dome_model,
+                diurnal_timer=diurnal_timer,
+                dome_model=dome_model,
                 glass_temperature_model=SimpleNamespace(median_temperature=0.0),
-                weather_model=self.weather_model,
-                indoor_ess_index=112,
-                ess_timeout=20,
+                weather_model=weather_model,
                 glycol_setpoint_delta=-2,
                 heater_setpoint_delta=-1,
                 top_end_setpoint_delta=-1,

--- a/tests/test_tma.py
+++ b/tests/test_tma.py
@@ -263,32 +263,6 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self.assertTrue(heater_setpoint is None)
         self.assertTrue(top_end_setpoint is None)
 
-    async def test_no_ess112(self) -> None:
-        """tma_model.monitor() should raise if ESS112 does not send data."""
-        indoor_temperature = None
-        glycol_setpoint_delta = -2
-        heater_setpoint_delta = -1
-        top_end_setpoint_delta = -1
-
-        with self.assertRaises(RuntimeError):
-            glycol_setpoint, heater_setpoint, top_end_setpoint, _ = (
-                await self.run_with_parameters(
-                    indoor_temperature=indoor_temperature,
-                    glycol_setpoint_delta=glycol_setpoint_delta,
-                    heater_setpoint_delta=heater_setpoint_delta,
-                    top_end_setpoint_delta=top_end_setpoint_delta,
-                    features_to_disable=[""],
-                )
-            )
-
-            self.assertTrue(glycol_setpoint is None)
-            self.assertTrue(heater_setpoint is None)
-            self.assertTrue(top_end_setpoint is None)
-
-            # Should not matter how long this sleep is because it should
-            # be interrupted by the RuntimeError.
-            await asyncio.sleep(60)
-
     async def test_fan_speed(self) -> None:
         """Compare behavior with specifications in OSW-820."""
         diurnal_timer = eas.diurnal_timer.DiurnalTimer()

--- a/tests/test_weather_model.py
+++ b/tests/test_weather_model.py
@@ -56,6 +56,10 @@ class TestGetLastTwilightTemperature(
             log=log,
             diurnal_timer=self.diurnal_timer,
             efd_name="mocked",
+            ess_index=301,
+            indoor_ess_index=112,
+            wind_average_window=1800,
+            wind_minimum_window=600,
         )
         await super().asyncSetUp()
 


### PR DESCRIPTION
This change implements control of HVAC chiller setpoints by EAS. The rules for applying chiller setpoints is laid out in the Jira ticket https://rubinobs.atlassian.net/browse/OSW-860. I got substantial clarification from Brian Stalder, so the comments are worth looking at. The gist is that the EAS takes a measurement of indoor temperature and subtracts 7.5 to find the "average" chiller setpoint. It then chooses setpoints for chiller 1 and chiller 2 that are 1 degree apart.

This PR also includes significant re-organization of the ts_config_ocs configuration file, to make it easier to read.