### PR TITLE
OSW-1999: Make active AHUs an EAS configuration.

### DIFF
--- a/doc/news/OSW-1999.feature.rst
+++ b/doc/news/OSW-1999.feature.rst
@@ -1,0 +1,1 @@
+Made active AHUs an EAS configuration.

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -59,6 +59,9 @@ class HvacModel:
         The offset that will be added to the measured temperature in
         selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
         measured in °C.
+    ahu_control : `list`[`int`]
+        The AHU numbers that EAS is allowed to control. Values correspond
+        to AHUs 1 through 4.
     setpoint_lower_limit : `float`
         The minimum allowed setpoint for thermal control. If a lower setpoint
         than this is indicated from the ESS temperature readings, this setpoint
@@ -111,6 +114,7 @@ class HvacModel:
         weather_model: WeatherModel,
         hvac_remote: salobj.Remote,
         ahu_setpoint_delta: float,
+        ahu_control: list[int],
         setpoint_lower_limit: float,
         wind_threshold: float,
         vec04_hold_time: float,
@@ -136,6 +140,7 @@ class HvacModel:
         self.dome_model = dome_model
         self.weather_model = weather_model
         self.ahu_setpoint_delta = ahu_setpoint_delta
+        self.ahu_control = ahu_control
         self.setpoint_lower_limit = setpoint_lower_limit
         self.wind_threshold = wind_threshold
         self.vec04_hold_time = vec04_hold_time
@@ -157,6 +162,21 @@ class HvacModel:
         # The remote
         self.hvac_remote = hvac_remote
 
+    def get_controlled_ahus(self) -> tuple[DeviceId, ...]:
+        """Return the AHU device IDs configured for EAS control.
+
+        Returns
+        -------
+        device_tuple : `tuple`[`DeviceId`, ...]
+        """
+        device_ids = {
+            1: DeviceId.lowerAHU01P05,
+            2: DeviceId.lowerAHU02P05,
+            3: DeviceId.lowerAHU03P05,
+            4: DeviceId.lowerAHU04P05,
+        }
+        return tuple(device_ids[ahu] for ahu in self.ahu_control)
+
     @classmethod
     def get_config_schema(cls) -> str:
         return yaml.safe_load(
@@ -172,6 +192,14 @@ properties:
       The offset that will be applied to the measured temperature in
       selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
       measured in °C.
+  ahu_control:
+    type: array
+    default: [1, 2, 3, 4]
+    description: AHU numbers that EAS is allowed to control.
+    items:
+      type: integer
+      enum: [1, 2, 3, 4]
+    uniqueItems: true
   setpoint_lower_limit:
     type: number
     default: 6.0
@@ -219,6 +247,7 @@ properties:
     description: Absolute maximum setpoint (°C) allowed for the warmer glycol chiller.
 required:
   - ahu_setpoint_delta
+  - ahu_control
   - setpoint_lower_limit
   - wind_threshold
   - vec04_hold_time
@@ -335,15 +364,10 @@ additionalProperties: false
 
             if shutter_closed != cached_shutter_closed:
                 cached_shutter_closed = shutter_closed
-                ahus = (
-                    DeviceId.lowerAHU04P05,
-                    DeviceId.lowerAHU03P05,
-                    DeviceId.lowerAHU02P05,
-                    DeviceId.lowerAHU01P05,
-                )
+                ahus = self.get_controlled_ahus()
                 if shutter_closed:
                     if "ahu" not in self.features_to_disable:
-                        # Enable the four AHUs
+                        # Enable the configured AHUs
                         self.log.info("Enabling HVAC AHUs!")
                         enable_device_list.extend(ahus)
 
@@ -392,12 +416,7 @@ additionalProperties: false
                                     "minFanSetpoint": math.nan,
                                     "antiFreezeTemperature": math.nan,
                                 }
-                                for device_id in (
-                                    DeviceId.lowerAHU01P05,
-                                    DeviceId.lowerAHU02P05,
-                                    DeviceId.lowerAHU03P05,
-                                    DeviceId.lowerAHU04P05,
-                                )
+                                for device_id in self.get_controlled_ahus()
                             ]
                         )
 
@@ -620,7 +639,7 @@ additionalProperties: false
                         warned_no_temperature = True
 
                 else:
-                    # Apply setpoint for each of the 4 AHUs
+                    # Apply setpoint for each configured AHU
                     await self.config_lower_ahu(
                         [
                             {
@@ -630,12 +649,7 @@ additionalProperties: false
                                 "minFanSetpoint": math.nan,
                                 "antiFreezeTemperature": math.nan,
                             }
-                            for device_id in (
-                                DeviceId.lowerAHU01P05,
-                                DeviceId.lowerAHU02P05,
-                                DeviceId.lowerAHU03P05,
-                                DeviceId.lowerAHU04P05,
-                            )
+                            for device_id in self.get_controlled_ahus()
                         ]
                     )
 

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -32,6 +32,7 @@ from astropy.time import Time
 from lsst.ts import salobj, utils
 from lsst.ts.xml.enums.HVAC import DeviceId
 
+# TODO: OSW-2022 remove this fallback when it becomes available from ts_xml.
 try:
     from lsst.ts.xml.enums.EAS import AHU
 except ImportError:
@@ -201,7 +202,10 @@ properties:
   ahu_control:
     type: array
     default: [1, 2, 3, 4]
-    description: AHU numbers that EAS is allowed to control.
+    description: >-
+      AHU numbers that EAS is allowed to control. These numbers refer
+      to the devices `lowerAHU01P05` - `lowerAHU04P05` in
+      :class:`~lsst.ts.xml.enums.HVAC.DeviceId`.
     items:
       type: integer
       enum: [1, 2, 3, 4]
@@ -253,7 +257,6 @@ properties:
     description: Absolute maximum setpoint (°C) allowed for the warmer glycol chiller.
 required:
   - ahu_setpoint_delta
-  - ahu_control
   - setpoint_lower_limit
   - wind_threshold
   - vec04_hold_time

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -32,6 +32,18 @@ from astropy.time import Time
 from lsst.ts import salobj, utils
 from lsst.ts.xml.enums.HVAC import DeviceId
 
+try:
+    from lsst.ts.xml.enums.EAS import AHU
+except ImportError:
+    import enum
+
+    class AHU(enum.IntEnum):  # type: ignore[no-redef]
+        lowerAHU01P05 = 1
+        lowerAHU02P05 = 2
+        lowerAHU03P05 = 3
+        lowerAHU04P05 = 4
+
+
 from .cmdwrapper import close_command_tasks, command_wrapper
 from .diurnal_timer import DiurnalTimer
 from .dome_model import DomeModel
@@ -169,13 +181,7 @@ class HvacModel:
         -------
         device_tuple : `tuple`[`DeviceId`, ...]
         """
-        device_ids = {
-            1: DeviceId.lowerAHU01P05,
-            2: DeviceId.lowerAHU02P05,
-            3: DeviceId.lowerAHU03P05,
-            4: DeviceId.lowerAHU04P05,
-        }
-        return tuple(device_ids[ahu] for ahu in self.ahu_control)
+        return tuple(DeviceId[AHU(ahu).name] for ahu in self.ahu_control)
 
     @classmethod
     def get_config_schema(cls) -> str:

--- a/tests/config/hvac_ahu_control_custom.yaml
+++ b/tests/config/hvac_ahu_control_custom.yaml
@@ -1,0 +1,14 @@
+ahu_setpoint_delta: 0.0
+ahu_control:
+  - 1
+  - 3
+setpoint_lower_limit: 6.0
+wind_threshold: 10.0
+vec04_hold_time: 0.0
+glycol_band_low: -10.0
+glycol_band_high: -5.0
+glycol_average_offset: -7.5
+glycol_dew_point_margin: 1.0
+glycol_setpoints_delta: 1.0
+glycol_absolute_minimum: -10.0
+glycol_absolute_maximum: 10.0

--- a/tests/config/hvac_ahu_control_default.yaml
+++ b/tests/config/hvac_ahu_control_default.yaml
@@ -1,0 +1,11 @@
+ahu_setpoint_delta: 0.0
+setpoint_lower_limit: 6.0
+wind_threshold: 10.0
+vec04_hold_time: 0.0
+glycol_band_low: -10.0
+glycol_band_high: -5.0
+glycol_average_offset: -7.5
+glycol_dew_point_margin: 1.0
+glycol_setpoints_delta: 1.0
+glycol_absolute_minimum: -10.0
+glycol_absolute_maximum: 10.0

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -159,9 +159,10 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             nightly_maximum_indoor_dew_point=-10.0,
         )
 
-    def make_model(self, **overrides: float | list[str] | None) -> hvac_model.HvacModel:
+    def make_model(self, **overrides: float | list[int] | list[str] | None) -> hvac_model.HvacModel:
         params = dict(
             ahu_setpoint_delta=0.0,
+            ahu_control=[1, 2, 3, 4],
             setpoint_lower_limit=6.0,
             wind_threshold=10.0,
             vec04_hold_time=0.0,
@@ -489,6 +490,33 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             # AHUs enabled on close
             self.assertIn(ahu, self.hvac.enable_called)
 
+    async def test_ahu_control_limits_shutter_commands(self) -> None:
+        """Only configured AHUs should be enabled and disabled."""
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0
+
+        model = self.make_model(ahu_control=[2, 4])
+        task = asyncio.create_task(model.control_ahus_and_vec04())
+
+        await asyncio.sleep(STD_SLEEP)
+        self.dome.is_closed = True
+        await asyncio.sleep(STD_SLEEP)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        for ahu in (DeviceId.lowerAHU02P05, DeviceId.lowerAHU04P05):
+            self.assertIn(ahu, self.hvac.disable_called)
+            self.assertIn(ahu, self.hvac.enable_called)
+
+        for ahu in (DeviceId.lowerAHU01P05, DeviceId.lowerAHU03P05):
+            self.assertNotIn(ahu, self.hvac.disable_called)
+            self.assertNotIn(ahu, self.hvac.enable_called)
+
     async def test_vec04_disabled(self) -> None:
         """VEC04 commands are not sent if 'vec04' in `features_to_disable`."""
         self.dome.is_closed = False
@@ -693,6 +721,44 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(self.hvac.ahu_setpoints, case["expect_setpoints"])
                 # reset for next scenario
                 self.hvac.ahu_setpoints.clear()
+
+    def test_config_schema_ahu_control(self) -> None:
+        validator = salobj.DefaultingValidator(hvac_model.HvacModel.get_config_schema())
+
+        validated = validator.validate(
+            dict(
+                ahu_setpoint_delta=0.0,
+                setpoint_lower_limit=6.0,
+                wind_threshold=10.0,
+                vec04_hold_time=0.0,
+                glycol_band_low=-10.0,
+                glycol_band_high=-5.0,
+                glycol_average_offset=-7.5,
+                glycol_dew_point_margin=1.0,
+                glycol_setpoints_delta=1.0,
+                glycol_absolute_minimum=-10.0,
+                glycol_absolute_maximum=10.0,
+            )
+        )
+        self.assertEqual(validated["ahu_control"], [1, 2, 3, 4])
+
+        validated = validator.validate(
+            dict(
+                ahu_setpoint_delta=0.0,
+                ahu_control=[1, 3],
+                setpoint_lower_limit=6.0,
+                wind_threshold=10.0,
+                vec04_hold_time=0.0,
+                glycol_band_low=-10.0,
+                glycol_band_high=-5.0,
+                glycol_average_offset=-7.5,
+                glycol_dew_point_margin=1.0,
+                glycol_setpoints_delta=1.0,
+                glycol_absolute_minimum=-10.0,
+                glycol_absolute_maximum=10.0,
+            )
+        )
+        self.assertEqual(validated["ahu_control"], [1, 3])
 
     def basic_make_csc(
         self,

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -22,10 +22,13 @@
 import asyncio
 import logging
 import math
+import types
 import unittest
+from pathlib import Path
 from typing import NotRequired, TypedDict
 
 import astropy
+import yaml
 
 from lsst.ts import salobj
 from lsst.ts.eas import hvac_model
@@ -33,6 +36,7 @@ from lsst.ts.xml.enums.HVAC import DeviceId
 
 STD_TIMEOUT = 10
 STD_SLEEP = 2
+CONFIG_PATH = Path(__file__).parent / "config"
 
 
 class WeatherModelMock:
@@ -138,6 +142,27 @@ class HvacMock(salobj.BaseCsc):
 
 
 class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
+    def get_config(self, filename: str) -> types.SimpleNamespace:
+        """Get a config dict from tests/data.
+
+        This should always be a good config,
+        because validation is done by the ESS CSC,
+        not the data client.
+
+        Parameters
+        ----------
+        filename : `str` or `pathlib.Path`
+            Name of config file, including ".yaml" suffix.
+
+        Returns
+        -------
+        config : types.SimpleNamespace
+            The config dict.
+        """
+        with open(CONFIG_PATH / filename, "r") as f:
+            config_dict = yaml.safe_load(f.read())
+        return types.SimpleNamespace(**config_dict)
+
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
 
@@ -724,41 +749,15 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     def test_config_schema_ahu_control(self) -> None:
         validator = salobj.DefaultingValidator(hvac_model.HvacModel.get_config_schema())
+        scenarios = [
+            ("hvac_ahu_control_default.yaml", [1, 2, 3, 4]),
+            ("hvac_ahu_control_custom.yaml", [1, 3]),
+        ]
 
-        validated = validator.validate(
-            dict(
-                ahu_setpoint_delta=0.0,
-                setpoint_lower_limit=6.0,
-                wind_threshold=10.0,
-                vec04_hold_time=0.0,
-                glycol_band_low=-10.0,
-                glycol_band_high=-5.0,
-                glycol_average_offset=-7.5,
-                glycol_dew_point_margin=1.0,
-                glycol_setpoints_delta=1.0,
-                glycol_absolute_minimum=-10.0,
-                glycol_absolute_maximum=10.0,
-            )
-        )
-        self.assertEqual(validated["ahu_control"], [1, 2, 3, 4])
-
-        validated = validator.validate(
-            dict(
-                ahu_setpoint_delta=0.0,
-                ahu_control=[1, 3],
-                setpoint_lower_limit=6.0,
-                wind_threshold=10.0,
-                vec04_hold_time=0.0,
-                glycol_band_low=-10.0,
-                glycol_band_high=-5.0,
-                glycol_average_offset=-7.5,
-                glycol_dew_point_margin=1.0,
-                glycol_setpoints_delta=1.0,
-                glycol_absolute_minimum=-10.0,
-                glycol_absolute_maximum=10.0,
-            )
-        )
-        self.assertEqual(validated["ahu_control"], [1, 3])
+        for filename, expected_ahu_control in scenarios:
+            with self.subTest(config_path=filename):
+                validated = validator.validate(vars(self.get_config(filename)))
+                self.assertEqual(validated["ahu_control"], expected_ahu_control)
 
     def basic_make_csc(
         self,


### PR DESCRIPTION
Adds an item to the configuration schema to allow selection of specific AHUs. Only those AHUs will be commanded by EAS.