### PR TITLE
OSW-1372: Add M1M3 and topend closedatnite and HVAC params.

### DIFF
--- a/doc/news/OSW-1372.feature.rst
+++ b/doc/news/OSW-1372.feature.rst
@@ -1,0 +1,1 @@
+Added M1M3 and topend closedatnite and HVAC params.

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -53,6 +53,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             * `glycol_chillers`: Glycol chillers will not be controlled in HVAC.
             * `fanspeed`: MTM1M3TS fans will not be controlled.
             * `m1m3ts`: MTM1M3TS setpoints will not be applied.
+            * `closedatnite`: Nighttime closed-dome setpoint control will not run.
             * `require_dome_open`: functionality will operate even when the dome is closed.
         type: array
         items:
@@ -64,6 +65,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             - glycol_chillers
             - fanspeed
             - m1m3ts
+            - closedatnite
             - require_dome_open
       twilight_definition:
         description: >

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -72,6 +72,10 @@ class HvacModel:
         The offset that will be added to the measured temperature in
         selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
         measured in °C.
+    ahu_setpoint_delta_closedatnite : `float`
+        The offset that will be added to the measured temperature in
+        selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
+        during nighttime closed-dome operation, measured in °C.
     ahu_control : `list`[`int`]
         The AHU numbers that EAS is allowed to control. Values correspond
         to AHUs 1 through 4.
@@ -127,6 +131,7 @@ class HvacModel:
         weather_model: WeatherModel,
         hvac_remote: salobj.Remote,
         ahu_setpoint_delta: float,
+        ahu_setpoint_delta_closedatnite: float,
         ahu_control: list[int],
         setpoint_lower_limit: float,
         wind_threshold: float,
@@ -153,6 +158,7 @@ class HvacModel:
         self.dome_model = dome_model
         self.weather_model = weather_model
         self.ahu_setpoint_delta = ahu_setpoint_delta
+        self.ahu_setpoint_delta_closedatnite = ahu_setpoint_delta_closedatnite
         self.ahu_control = ahu_control
         self.setpoint_lower_limit = setpoint_lower_limit
         self.wind_threshold = wind_threshold
@@ -199,6 +205,13 @@ properties:
       The offset that will be applied to the measured temperature in
       selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
       measured in °C.
+  ahu_setpoint_delta_closedatnite:
+    type: number
+    default: -1.0
+    description: >-
+      The offset that will be applied to the measured temperature in
+      selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
+      during nighttime closed-dome operation measured in °C.
   ahu_control:
     type: array
     default: [1, 2, 3, 4]
@@ -633,13 +646,17 @@ additionalProperties: false
         warned_no_temperature = False
 
         while self.diurnal_timer.is_running:
+            if "closedatnite" in self.features_to_disable:
+                await asyncio.sleep(HVAC_SLEEP_TIME)
+                continue
+
             if self.diurnal_timer.is_night(Time.now()) and self.dome_model.is_closed:
                 if "room_setpoint" in self.features_to_disable:
                     await asyncio.sleep(HVAC_SLEEP_TIME)
                     continue
 
                 setpoint = max(
-                    self.weather_model.current_temperature + self.ahu_setpoint_delta,
+                    self.weather_model.current_temperature + self.ahu_setpoint_delta_closedatnite,
                     self.setpoint_lower_limit,
                 )
                 if math.isnan(setpoint):

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -77,6 +77,12 @@ class TmaModel:
     top_end_setpoint_delta : `float`
         The difference between the indoor (ESS:112) temperature and the
         setpoint to apply for the top end, via MTMount.setThermal.
+    m1m3_extra_delta_closedatnite : `float`
+        Extra temperature offset (°C) applied during nighttime closed-dome
+        operation on top of the configured glycol and heater setpoint deltas.
+    top_end_setpoint_delta_closedatnite : `float`
+        The difference between the indoor temperature and the top-end
+        setpoint during nighttime closed-dome operation.
     m1m3_setpoint_cadence : `float`
         The cadence at which applySetpoints commands should be sent to
         MTM1M3TS (seconds).
@@ -121,6 +127,8 @@ class TmaModel:
         glycol_setpoint_delta: float,
         heater_setpoint_delta: float,
         top_end_setpoint_delta: float,
+        m1m3_extra_delta_closedatnite: float,
+        top_end_setpoint_delta_closedatnite: float,
         m1m3_setpoint_cadence: float,
         m1m3ts_delay_mode: dict,
         setpoint_deadband_heating: float,
@@ -150,6 +158,8 @@ class TmaModel:
         self.glycol_setpoint_delta = glycol_setpoint_delta
         self.heater_setpoint_delta = heater_setpoint_delta
         self.top_end_setpoint_delta = top_end_setpoint_delta
+        self.m1m3_extra_delta_closedatnite = m1m3_extra_delta_closedatnite
+        self.top_end_setpoint_delta_closedatnite = top_end_setpoint_delta_closedatnite
         self.m1m3_setpoint_cadence = m1m3_setpoint_cadence
         self.m1m3ts_delay_mode = m1m3ts_delay_mode
         self.setpoint_deadband_heating = setpoint_deadband_heating
@@ -200,6 +210,18 @@ properties:
     default: -1.0
   top_end_setpoint_delta:
     description: Difference (°C) between the ambient temperature and MTMount thermal setpoint.
+    type: number
+    default: -1.0
+  m1m3_extra_delta_closedatnite:
+    description: >-
+      Additional difference (°C) applied during nighttime closed-dome operation
+      on top of the configured M1M3TS glycol and heater setpoint deltas.
+    type: number
+    default: 0.0
+  top_end_setpoint_delta_closedatnite:
+    description: >-
+      Difference (°C) between the ambient temperature and MTMount thermal setpoint
+      during nighttime closed-dome operation.
     type: number
     default: -1.0
   m1m3_setpoint_cadence:
@@ -322,6 +344,8 @@ required:
   - glycol_setpoint_delta
   - heater_setpoint_delta
   - top_end_setpoint_delta
+  - m1m3_extra_delta_closedatnite
+  - top_end_setpoint_delta_closedatnite
   - m1m3_setpoint_cadence
   - m1m3ts_delay_mode
   - setpoint_deadband_heating
@@ -377,6 +401,7 @@ additionalProperties: false
         try:
             await asyncio.gather(
                 self.follow_ess_indoor(),
+                self.apply_setpoint_at_night(),
                 self.wait_for_sunrise(),
             )
         finally:
@@ -391,10 +416,15 @@ additionalProperties: false
 
         self.log.debug("TmaModel.monitor closing...")
 
-    async def apply_setpoints(self, setpoint: float) -> None:
+    async def apply_setpoints(self, setpoint: float, *, delta_adjustment: float = 0.0) -> None:
         if "m1m3ts" not in self.features_to_disable:
-            glycol_setpoint = setpoint + self.glycol_setpoint_delta + self.glycol_setpoint_delta_adjustment
-            heaters_setpoint = setpoint + self.heater_setpoint_delta
+            glycol_setpoint = (
+                setpoint
+                + self.glycol_setpoint_delta
+                + self.glycol_setpoint_delta_adjustment
+                + delta_adjustment
+            )
+            heaters_setpoint = setpoint + self.heater_setpoint_delta + delta_adjustment
             self.log.debug(f"Setting MTM1MTS: {glycol_setpoint=:.2f}°C {heaters_setpoint=:.2f}°C")
             await self.send_apply_setpoints(
                 glycol_setpoint=glycol_setpoint,
@@ -614,6 +644,10 @@ additionalProperties: false
         while self.diurnal_timer.is_running:
             async with self.diurnal_timer.sunrise_condition:
                 await self.diurnal_timer.sunrise_condition.wait()
+
+                # Avoid stepping on setpoints from the closedatnite coroutine.
+                await asyncio.sleep(self.m1m3_setpoint_cadence)
+
                 last_twilight_temperature = await self.weather_model.get_last_twilight_temperature()
                 if self.diurnal_timer.is_running and last_twilight_temperature is not None:
                     self.log.info(
@@ -629,6 +663,49 @@ additionalProperties: false
                             top_end_chiller_setpoint=chiller_setpoint,
                             top_end_chiller_state=ThermalCommandState.ON,
                         )
+
+    async def apply_setpoint_at_night(self) -> None:
+        """Control M1M3TS and top-end setpoints during the night.
+
+        At night time (defined by `DiurnalTimer.is_night`) the M1M3TS and
+        top-end setpoints should be applied based on the current outdoor
+        temperature if the dome is closed. If the dome is open, this method
+        does not command either subsystem.
+        """
+        warned_no_temperature = False
+
+        while self.diurnal_timer.is_running:
+            # This coroutine should idle if "require_dome_open" is selected.
+            # Otherwise, there would be a conflict between this coroutine
+            # and the one that controls the setpoints based on an indoor
+            # temperature.
+            if "closedatnite" in self.features_to_disable or "require_dome_open" in self.features_to_disable:
+                await asyncio.sleep(self.m1m3_setpoint_cadence)
+                continue
+
+            if self.diurnal_timer.is_night(Time.now()) and self.dome_model.is_closed:
+                outdoor_temperature = self.weather_model.current_temperature
+
+                if outdoor_temperature is None or math.isnan(outdoor_temperature):
+                    if not warned_no_temperature:
+                        self.log.warning("Failed to collect a temperature sample for nighttime TMA setpoint.")
+                        warned_no_temperature = True
+                else:
+                    warned_no_temperature = False
+                    await self.apply_setpoints(
+                        outdoor_temperature,
+                        delta_adjustment=self.m1m3_extra_delta_closedatnite,
+                    )
+
+                    if "top_end" not in self.features_to_disable:
+                        await self.send_set_thermal(
+                            top_end_chiller_setpoint=(
+                                outdoor_temperature + self.top_end_setpoint_delta_closedatnite
+                            ),
+                            top_end_chiller_state=ThermalCommandState.ON,
+                        )
+
+            await asyncio.sleep(self.m1m3_setpoint_cadence)
 
     async def close(self) -> None:
         """Cancel any in-flight command tasks."""

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -187,6 +187,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     def make_model(self, **overrides: float | list[int] | list[str] | None) -> hvac_model.HvacModel:
         params = dict(
             ahu_setpoint_delta=0.0,
+            ahu_setpoint_delta_closedatnite=0.0,
             ahu_control=[1, 2, 3, 4],
             setpoint_lower_limit=6.0,
             wind_threshold=10.0,
@@ -671,6 +672,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             night: bool
             closed: bool
             ahu_setpoint_delta: NotRequired[float]
+            ahu_setpoint_delta_closedatnite: NotRequired[float]
             temp: float
             expect_setpoints: dict[str, float]
 
@@ -695,9 +697,10 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 "night": True,
                 "closed": True,
                 "temp": 9.0,
-                "ahu_setpoint_delta": -1.0,
+                "ahu_setpoint_delta": 0.0,
+                "ahu_setpoint_delta_closedatnite": -1.5,
                 "expect_setpoints": {
-                    ahu: 8.0
+                    ahu: 7.5
                     for ahu in (
                         DeviceId.airHandlingUnit01Dome,
                         DeviceId.airHandlingUnit02Dome,
@@ -736,7 +739,10 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 self.dome.is_closed = case["closed"]
                 self.weather.current_temperature = case["temp"]
 
-                model = self.make_model(ahu_setpoint_delta=case.get("ahu_setpoint_delta", 0.0))
+                model = self.make_model(
+                    ahu_setpoint_delta=case.get("ahu_setpoint_delta", 0.0),
+                    ahu_setpoint_delta_closedatnite=case.get("ahu_setpoint_delta_closedatnite", 0.0),
+                )
                 task = asyncio.create_task(model.apply_setpoint_at_night())
 
                 await asyncio.sleep(STD_SLEEP)

--- a/tests/test_tma.py
+++ b/tests/test_tma.py
@@ -21,6 +21,7 @@
 
 import asyncio
 import logging
+import math
 import typing
 import unittest
 from collections import deque
@@ -82,6 +83,7 @@ class MTMountMock(salobj.BaseCsc):
 class WeatherModelMock:
     def __init__(self, last_twilight_temperature: float) -> None:
         self.last_twilight_temperature = last_twilight_temperature
+        self.current_temperature: float | None = 10
         self.current_indoor_temperature: float | None = 10
 
     async def get_last_twilight_temperature(self) -> float:
@@ -103,14 +105,20 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self,
         indoor_temperature: float | None = 10,
         signal_sunrise: bool = False,
+        night: bool = False,
+        dome_closed: bool = False,
+        run_monitor: bool = True,
         **model_args: typing.Any,
     ) -> tuple[float | None, float | None, float | None, list[float] | None]:
         self.diurnal_timer = eas.diurnal_timer.DiurnalTimer()
         self.diurnal_timer.is_running = True
+        self.diurnal_timer.is_night = lambda _: night
 
         self.weather_model = WeatherModelMock(self.last_twilight_temperature)
+        self.weather_model.current_temperature = indoor_temperature
         self.weather_model.current_indoor_temperature = indoor_temperature
-        self.dome_model = DomeModelMock(is_closed=False)
+        self.dome_model = DomeModelMock(is_closed=dome_closed)
+        cadence = 10 if run_monitor else STD_SLEEP
 
         async with (
             M1M3TSMock() as mock_m1m3ts,
@@ -132,7 +140,11 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=model_args["glycol_setpoint_delta"],
                 heater_setpoint_delta=model_args["heater_setpoint_delta"],
                 top_end_setpoint_delta=model_args["top_end_setpoint_delta"],
-                m1m3_setpoint_cadence=10,
+                m1m3_extra_delta_closedatnite=model_args.get("m1m3_extra_delta_closedatnite", 0.0),
+                top_end_setpoint_delta_closedatnite=model_args.get(
+                    "top_end_setpoint_delta_closedatnite", model_args["top_end_setpoint_delta"]
+                ),
+                m1m3_setpoint_cadence=cadence,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
                 maximum_heating_rate=100,
@@ -149,22 +161,29 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 m1m3ts_delay_mode=m1m3ts_delay_mode,
                 features_to_disable=model_args["features_to_disable"],
             )
-            monitor_task = asyncio.create_task(self.tma_model.monitor())
+            if run_monitor:
+                model_task = asyncio.create_task(self.tma_model.monitor())
+            else:
+                model_task = asyncio.create_task(self.tma_model.apply_setpoint_at_night())
 
-            await asyncio.sleep(15)
+            await asyncio.sleep(2 * cadence)
 
             if signal_sunrise:
+                self.diurnal_timer.is_night = lambda _: False
+                self.dome_model.is_closed = True
                 async with self.diurnal_timer.sunrise_condition:
                     self.diurnal_timer.sunrise_condition.notify_all()
-                await asyncio.sleep(1)
-            else:
-                await asyncio.sleep(20)
 
-            monitor_task.cancel()
+            await asyncio.sleep(2 * cadence)
+
+            model_task.cancel()
             try:
-                await monitor_task
+                await asyncio.wait_for(model_task, timeout=STD_TIMEOUT)
             except asyncio.CancelledError:
                 pass
+            except TimeoutError:
+                task_name = "TmaModel.monitor" if run_monitor else "TmaModel.apply_setpoint_at_night"
+                self.fail(f"{task_name} did not stop before timeout")
 
             return (
                 mock_m1m3ts.glycol_setpoint,
@@ -172,6 +191,94 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 mock_mtmount.top_end_setpoint,
                 mock_m1m3ts.fan_rpm,
             )
+
+    async def test_apply_setpoint_at_night(self) -> None:
+        """Nighttime closed-dome control should mirror the HVAC behavior."""
+
+        class SubtestCase(typing.TypedDict):
+            name: str
+            night: bool
+            dome_closed: bool
+            indoor_temperature: float
+            expect_m1m3: bool
+            expect_top_end: bool
+
+        scenarios: list[SubtestCase] = [
+            {
+                "name": "night closed apply setpoints",
+                "night": True,
+                "dome_closed": True,
+                "indoor_temperature": 6.0,
+                "expect_m1m3": True,
+                "expect_top_end": True,
+            },
+            {
+                "name": "night open no setpoints",
+                "night": True,
+                "dome_closed": False,
+                "indoor_temperature": 9.0,
+                "expect_m1m3": False,
+                "expect_top_end": False,
+            },
+            {
+                "name": "day closed no setpoints",
+                "night": False,
+                "dome_closed": True,
+                "indoor_temperature": 12.0,
+                "expect_m1m3": False,
+                "expect_top_end": False,
+            },
+            {
+                "name": "night closed NaN temp no setpoints",
+                "night": True,
+                "dome_closed": True,
+                "indoor_temperature": math.nan,
+                "expect_m1m3": False,
+                "expect_top_end": False,
+            },
+        ]
+
+        glycol_setpoint_delta = -2.0
+        heater_setpoint_delta = -1.0
+        top_end_setpoint_delta = -0.5
+        m1m3_extra_delta_closedatnite = 0.5
+        top_end_setpoint_delta_closedatnite = -1.5
+
+        for case in scenarios:
+            with self.subTest(case=case["name"]):
+                glycol_setpoint, heater_setpoint, top_end_setpoint, _ = await self.run_with_parameters(
+                    indoor_temperature=case["indoor_temperature"],
+                    night=case["night"],
+                    dome_closed=case["dome_closed"],
+                    run_monitor=False,
+                    glycol_setpoint_delta=glycol_setpoint_delta,
+                    heater_setpoint_delta=heater_setpoint_delta,
+                    top_end_setpoint_delta=top_end_setpoint_delta,
+                    m1m3_extra_delta_closedatnite=m1m3_extra_delta_closedatnite,
+                    top_end_setpoint_delta_closedatnite=top_end_setpoint_delta_closedatnite,
+                    features_to_disable=[],
+                )
+
+                if case["expect_m1m3"]:
+                    self.assertEqual(
+                        glycol_setpoint,
+                        case["indoor_temperature"] + glycol_setpoint_delta + m1m3_extra_delta_closedatnite,
+                    )
+                    self.assertEqual(
+                        heater_setpoint,
+                        case["indoor_temperature"] + heater_setpoint_delta + m1m3_extra_delta_closedatnite,
+                    )
+                else:
+                    self.assertIsNone(glycol_setpoint)
+                    self.assertIsNone(heater_setpoint)
+
+                if case["expect_top_end"]:
+                    self.assertEqual(
+                        top_end_setpoint,
+                        case["indoor_temperature"] + top_end_setpoint_delta_closedatnite,
+                    )
+                else:
+                    self.assertIsNone(top_end_setpoint)
 
     async def test_m1m3ts_applysetpoints(self) -> None:
         """M1M3TS.applySetpoint should be called at sunrise."""
@@ -316,6 +423,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=-1,
+                m1m3_extra_delta_closedatnite=0.0,
+                top_end_setpoint_delta_closedatnite=-1,
                 m1m3_setpoint_cadence=10,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -379,8 +488,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def test_delay_policy_time_delay(self) -> None:
         """Delay policy should gate tracking until the time delay elapses."""
-        delay_seconds = 5.0
         cadence = 0.05
+        delay_seconds = 10 * cadence
 
         async with (
             M1M3TSMock() as mock_m1m3ts,
@@ -408,6 +517,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2,
                 heater_setpoint_delta=0.0,
                 top_end_setpoint_delta=-1,
+                m1m3_extra_delta_closedatnite=0.0,
+                top_end_setpoint_delta_closedatnite=-1,
                 m1m3_setpoint_cadence=cadence,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -431,8 +542,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
             # Delay controller has registered an open event.
             self.assertEqual(len(dome_model.on_open), 1)
-            event, delay = dome_model.on_open.popleft()
-            self.assertEqual(delay, 0.0)
+            event, _ = dome_model.on_open.popleft()
 
             # Fire the event, but dome is still closed.
             # (This occurs if the dome is re-closed before the delay time.)
@@ -443,8 +553,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
             # TmaModel should have queued up a new event.
             self.assertEqual(len(dome_model.on_open), 1)
-            event, delay = dome_model.on_open.popleft()
-            self.assertEqual(delay, 0.0)
+            event, _ = dome_model.on_open.popleft()
 
             # Fire the event, but this time the dome is open.
             dome_model.is_closed = False
@@ -454,7 +563,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             self.assertIsNone(mock_m1m3ts.glycol_setpoint)
 
             # After the delay elapses, the controller should allow tracking.
-            await asyncio.sleep(delay_seconds + cadence)
+            await asyncio.sleep(2 * (cadence + delay_seconds))
 
             self.assertIsNotNone(mock_m1m3ts.heater_setpoint)
             self.assertIsNotNone(mock_m1m3ts.glycol_setpoint)


### PR DESCRIPTION
This change introduces nighttime setpoint control for the TMA that operates even when the dome is closed. Instead of disabling control when the dome is closed, the TMA now continues to update M1M3 and top-end setpoints during nighttime based on ambient (outdoor) temperature supplied by ESS:301.