### PR TITLE
Add nighttime control of glycol chillers.

### DIFF
--- a/doc/news/OSW-2128.bugfix.rst
+++ b/doc/news/OSW-2128.bugfix.rst
@@ -1,0 +1,1 @@
+Added nighttime control of glycol chillers.

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -546,14 +546,6 @@ additionalProperties: false
                     await asyncio.sleep(HVAC_SLEEP_TIME)
                     continue
 
-                # At night, reset the setpoints and do not control
-                # the glycol.
-                if self.diurnal_timer.is_night(Time.now()):
-                    self.glycol_setpoint1 = None
-                    self.glycol_setpoint2 = None
-                    await asyncio.sleep(HVAC_SLEEP_TIME)
-                    continue
-
                 # After the setpoints are chosen at noon, monitor
                 # the system and adjust setpoints if needed.
                 ambient_temperature = self.weather_model.current_indoor_temperature


### PR DESCRIPTION
This change causes chiller setpoints to be issued at all times. Setpoints are issued once per minute to ensure that they remain set even if accidentally changed. Rules for determining the setpoint are defined in OSW-860 and are not recomputed unless the temperature wanders outside of its band, except that they are recomputed at noon disregarding the temperature band.