### PR TITLE
OSW-1772: Add WeatherForecast remote.

### DIFF
--- a/doc/news/OSW-1772.feature.rst
+++ b/doc/news/OSW-1772.feature.rst
@@ -1,0 +1,1 @@
+Added WeatherForecast remote.

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -48,6 +48,10 @@ CONFIG_SCHEMA = yaml.safe_load(
         description: >-
           List of EAS functionalities to disable. Options are:
             * `room_setpoint`: HVAC setpoints will not be applied.
+            * `forecast`: All forecast-based setpoints will not be applied.
+            * `forecast_ahu`: HVAC forecast-based AHU setpoints will not be applied.
+            * `forecast_m1m3ts`: TMA forecast-based M1M3TS setpoints will not be applied.
+            * `forecast_top_end`: TMA forecast-based top end setpoints will not be applied.
             * `ahu`: HVAC AHUs will not be enabled / disabled.
             * `vec04`: VEC-04 exhaust fan will not be enabled / disabled.
             * `glycol_chillers`: Glycol chillers will not be controlled in HVAC.
@@ -59,7 +63,11 @@ CONFIG_SCHEMA = yaml.safe_load(
         items:
           type: string
           enum:
+            - forecast
             - room_setpoint
+            - forecast_ahu
+            - forecast_m1m3ts
+            - forecast_top_end
             - ahu
             - vec04
             - glycol_chillers

--- a/python/lsst/ts/eas/delay_controller.py
+++ b/python/lsst/ts/eas/delay_controller.py
@@ -93,7 +93,10 @@ class DelayPolicy:
     """
 
     is_ready: Callable[[float | None, float | None, float, float], bool]
-    on_hold: Callable[[float | None, float | None, float, ApplySetpointsCallback | None], Awaitable[None]]
+    on_hold: Callable[
+        [float | None, float | None, float, ApplySetpointsCallback | None],
+        Awaitable[None],
+    ]
 
 
 def within_tolerance(

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -37,6 +37,7 @@ from .glass_temperature_model import GlassTemperatureModel
 from .hvac_model import HvacModel
 from .tma_model import TmaModel
 from .weather_model import WeatherModel
+from .weatherforecast_model import WeatherForecastModel
 
 # Constants for the health monitor:
 FAILURE_TIMEOUT = 600  # Failure count will reset after monitor has run for this time (seconds).
@@ -119,6 +120,7 @@ class EasCsc(salobj.ConfigurableCsc):
         self.dome_model: DomeModel | None = None
         self.glass_temperature_model: GlassTemperatureModel | None = None
         self.weather_model: WeatherModel | None = None
+        self.weatherforecast_model: WeatherForecastModel | None = None
 
         self.dome_remote = salobj.Remote(
             domain=self.domain,
@@ -165,6 +167,12 @@ class EasCsc(salobj.ConfigurableCsc):
             domain=self.domain,
             name="HVAC",
             include=["summaryState"],
+        )
+        self.weatherforecast_remote = salobj.Remote(
+            domain=self.domain,
+            name="WeatherForecast",
+            readonly=True,
+            include=["hourlyTrend", "summaryState"],
         )
 
         self.ess_indoor_remote: salobj.Remote | None = None
@@ -275,6 +283,7 @@ class EasCsc(salobj.ConfigurableCsc):
             self.dome_model.set_pending_events()
 
         self.glass_temperature_model = GlassTemperatureModel(log=self.log)
+        self.weatherforecast_model = WeatherForecastModel(log=self.log)
 
         # Validate the sub-schemas and update with defaults.
         for object_type, attr in (
@@ -299,6 +308,7 @@ class EasCsc(salobj.ConfigurableCsc):
             diurnal_timer=self.diurnal_timer,
             dome_model=self.dome_model,
             weather_model=self.weather_model,
+            weatherforecast_model=self.weatherforecast_model,
             hvac_remote=self.hvac_remote,
             features_to_disable=self.config.features_to_disable,
             allow_send=self._allow_send,
@@ -310,6 +320,7 @@ class EasCsc(salobj.ConfigurableCsc):
             dome_model=self.dome_model,
             glass_temperature_model=self.glass_temperature_model,
             weather_model=self.weather_model,
+            weatherforecast_model=self.weatherforecast_model,
             m1m3ts_remote=self.mtm1m3ts_remote,
             mtmount_remote=self.mtmount_remote,
             features_to_disable=self.config.features_to_disable,
@@ -373,6 +384,7 @@ class EasCsc(salobj.ConfigurableCsc):
         assert self.dome_model is not None, "Dome model not initialized."
         assert self.glass_temperature_model is not None, "Glass model not initialized."
         assert self.weather_model is not None, "Weather Model not initialized."
+        assert self.weatherforecast_model is not None, "WeatherForecast model not initialized."
 
         if self.ess_indoor_remote is None or self.ess_outdoor_remote is None:
             raise RuntimeError(
@@ -392,6 +404,9 @@ class EasCsc(salobj.ConfigurableCsc):
         self.ess_outdoor_remote.tel_temperature.callback = self.weather_model.temperature_callback
         self.ess_indoor_remote.tel_dewPoint.callback = self.weather_model.indoor_dew_point_callback
         self.ess_indoor_remote.tel_temperature.callback = self.weather_model.indoor_temperature_callback
+        self.weatherforecast_remote.tel_hourlyTrend.callback = (
+            self.weatherforecast_model.hourly_trend_callback
+        )
 
     def disconnect_callbacks(self) -> None:
         """Disconnects callbacks from their remotes."""
@@ -412,6 +427,7 @@ class EasCsc(salobj.ConfigurableCsc):
         self.ess_outdoor_remote.tel_temperature.callback = None
         self.ess_indoor_remote.tel_dewPoint.callback = None
         self.ess_indoor_remote.tel_temperature.callback = None
+        self.weatherforecast_remote.tel_hourlyTrend.callback = None
 
     async def monitor_health(self) -> None:
         """Manage the `monitor_dome_shutter` control loop.

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -46,9 +46,10 @@ except ImportError:
 
 
 from .cmdwrapper import close_command_tasks, command_wrapper
-from .diurnal_timer import DiurnalTimer
+from .diurnal_timer import DiurnalTimer, get_local_noon_time
 from .dome_model import DomeModel
 from .weather_model import WeatherModel
+from .weatherforecast_model import WeatherForecastModel
 
 HVAC_SLEEP_TIME = 60.0  # How often to check the HVAC state (seconds)
 STD_TIMEOUT = 5  # seconds
@@ -68,6 +69,8 @@ class HvacModel:
         A model representing the dome state.
     weather_model : `WeatherModel`
         A model representing weather conditions.
+    weatherforecast_model : `WeatherForecastModel`
+        A model representing forecast conditions used for upcoming twilight.
     ahu_setpoint_delta : `float`
         The offset that will be added to the measured temperature in
         selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
@@ -118,6 +121,8 @@ class HvacModel:
          * vec04
          * ahu
          * room_setpoint
+         * forecast
+         * forecast_ahu
          * glycol_chillers
         Any other values are ignored.
     """
@@ -129,6 +134,7 @@ class HvacModel:
         diurnal_timer: DiurnalTimer,
         dome_model: DomeModel,
         weather_model: WeatherModel,
+        weatherforecast_model: WeatherForecastModel,
         hvac_remote: salobj.Remote,
         ahu_setpoint_delta: float,
         ahu_setpoint_delta_closedatnite: float,
@@ -144,6 +150,7 @@ class HvacModel:
         glycol_absolute_minimum: float,
         glycol_absolute_maximum: float,
         features_to_disable: list[str],
+        forecast_ahu_setpoint_delta: float | None = None,
         allow_send: Callable[[], bool] | None = None,
     ) -> None:
         self.log = log
@@ -157,6 +164,7 @@ class HvacModel:
         # Configuration parameters:
         self.dome_model = dome_model
         self.weather_model = weather_model
+        self.weatherforecast_model = weatherforecast_model
         self.ahu_setpoint_delta = ahu_setpoint_delta
         self.ahu_setpoint_delta_closedatnite = ahu_setpoint_delta_closedatnite
         self.ahu_control = ahu_control
@@ -164,6 +172,12 @@ class HvacModel:
         self.wind_threshold = wind_threshold
         self.vec04_hold_time = vec04_hold_time
         self.features_to_disable = features_to_disable
+
+        # Forecast-specific delta overrides
+        # (fall back to standard values when absent):
+        self.forecast_ahu_setpoint_delta = (
+            forecast_ahu_setpoint_delta if forecast_ahu_setpoint_delta is not None else ahu_setpoint_delta
+        )
 
         # Glycol chiller parameters:
         self.glycol_band_low = glycol_band_low
@@ -178,8 +192,15 @@ class HvacModel:
         self.glycol_setpoint1: float | None = None
         self.glycol_setpoint2: float | None = None
 
+        # When True, a forecast-driven setpoint is active and
+        # monitor_glycol_chillers should apply it rather than recomputing
+        # from the current indoor temperature. Cleared at twilight.
+        self.glycol_forecast_active: bool = False
+
         # The remote
         self.hvac_remote = hvac_remote
+
+        self.twilight_forecast_callback_id: int | None = None
 
     def get_controlled_ahus(self) -> tuple[DeviceId, ...]:
         """Return the AHU device IDs configured for EAS control.
@@ -268,6 +289,12 @@ properties:
     type: number
     default: 10.0
     description: Absolute maximum setpoint (°C) allowed for the warmer glycol chiller.
+  forecast_ahu_setpoint_delta:
+    type: [number, "null"]
+    default: null
+    description: >-
+      AHU setpoint offset (°C) used when driven by forecast. If absent,
+      ahu_setpoint_delta is used.
 required:
   - ahu_setpoint_delta
   - setpoint_lower_limit
@@ -324,6 +351,7 @@ additionalProperties: false
         tasks = [
             self.control_ahus_and_vec04(),
             self.wait_for_sunrise(),
+            self.monitor_twilight_forecast(),
             self.apply_setpoint_at_night(),
             self.adjust_glycol_chillers_at_noon(),
             self.monitor_glycol_chillers(),
@@ -343,6 +371,7 @@ additionalProperties: false
 
     async def close(self) -> None:
         """Cancel any in-flight command tasks."""
+        self.clear_twilight_forecast_callback()
         await close_command_tasks(self)
 
     async def control_ahus_and_vec04(self) -> None:
@@ -428,7 +457,6 @@ additionalProperties: false
                             last_twilight_temperature + self.ahu_setpoint_delta,
                             self.setpoint_lower_limit,
                         )
-
                         await self.config_lower_ahu(
                             [
                                 {
@@ -442,7 +470,81 @@ additionalProperties: false
                             ]
                         )
 
-    def compute_glycol_setpoints(self, ambient_temperature: float) -> tuple[float, float]:
+    def clear_twilight_forecast_callback(self) -> None:
+        if self.twilight_forecast_callback_id is None:
+            return
+        self.weatherforecast_model.remove_callback(self.twilight_forecast_callback_id)
+        self.twilight_forecast_callback_id = None
+        self.glycol_forecast_active = False
+
+    def set_twilight_forecast_callback(self) -> None:
+        self.clear_twilight_forecast_callback()
+        twilight_time = self.diurnal_timer.get_twilight_time(after=Time.now())
+        callback_id = self.weatherforecast_model.add_callback(
+            twilight_time.tai.unix,
+            self.handle_twilight_forecast,
+        )
+        self.twilight_forecast_callback_id = callback_id
+
+    def handle_twilight_forecast(self, predicted_temperature: float) -> None:
+        if not self.diurnal_timer.is_running:
+            return
+        if "room_setpoint" in self.features_to_disable or "forecast" in self.features_to_disable:
+            return
+        self.log.info(
+            f"Applying HVAC setpoints based on forecast twilight temperature: {predicted_temperature:.2f}°C"
+        )
+        asyncio.create_task(self.apply_forecast_setpoints(predicted_temperature))
+
+    async def apply_forecast_setpoints(self, predicted_temperature: float) -> None:
+        if "room_setpoint" not in self.features_to_disable and "forecast_ahu" not in self.features_to_disable:
+            setpoint = max(
+                predicted_temperature + self.forecast_ahu_setpoint_delta,
+                self.setpoint_lower_limit,
+            )
+            await self.config_lower_ahu(
+                [
+                    {
+                        "device_id": device_id,
+                        "workingSetpoint": setpoint,
+                        "maxFanSetpoint": math.nan,
+                        "minFanSetpoint": math.nan,
+                        "antiFreezeTemperature": math.nan,
+                    }
+                    for device_id in self.get_controlled_ahus()
+                ]
+            )
+
+    async def monitor_twilight_forecast(self) -> None:
+        """Run forecast callback between noon and evening twilight."""
+        # If started between noon and twilight, begin operating immediately
+        # without waiting for noon.
+        next_noon = get_local_noon_time()
+        if (
+            self.diurnal_timer.is_running
+            and self.diurnal_timer.twilight_time is not None
+            and self.diurnal_timer.twilight_time < next_noon
+        ):
+            self.set_twilight_forecast_callback()
+            async with self.diurnal_timer.twilight_condition:
+                await self.diurnal_timer.twilight_condition.wait()
+            self.clear_twilight_forecast_callback()
+
+        # Subsequently, wait for noon and start, then wait for
+        # twilight and stop, in a loop.
+        while self.diurnal_timer.is_running:
+            async with self.diurnal_timer.noon_condition:
+                await self.diurnal_timer.noon_condition.wait()
+            if not self.diurnal_timer.is_running:
+                break
+            self.set_twilight_forecast_callback()
+            async with self.diurnal_timer.twilight_condition:
+                await self.diurnal_timer.twilight_condition.wait()
+            self.clear_twilight_forecast_callback()
+
+    def compute_glycol_setpoints(
+        self, ambient_temperature: float, average_offset: float | None = None
+    ) -> tuple[float, float]:
         """Compute staggered glycol chiller setpoints.
 
         Compute staggered glycol chiller setpoints based on ambient
@@ -478,7 +580,9 @@ additionalProperties: false
             Active setpoint for chiller 2 (°C), the colder of the two.
         """
         # Compute a target average setpoint
-        target_average = ambient_temperature + self.glycol_average_offset
+        if average_offset is None:
+            average_offset = self.glycol_average_offset
+        target_average = ambient_temperature + average_offset
 
         # Incorporate dew point into the calculation - setpoint
         # average should not be lower than the dew point (with margin)
@@ -546,23 +650,28 @@ additionalProperties: false
                     await asyncio.sleep(HVAC_SLEEP_TIME)
                     continue
 
-                # After the setpoints are chosen at noon, monitor
-                # the system and adjust setpoints if needed.
-                ambient_temperature = self.weather_model.current_indoor_temperature
-                if ambient_temperature is not None and not self.check_glycol_setpoint(ambient_temperature):
-                    self.log.debug("Recomputing glycol setpoints.")
-                    glycol_setpoint1, glycol_setpoint2 = self.compute_glycol_setpoints(ambient_temperature)
-
-                    if all(
-                        (
-                            glycol_setpoint1 is not None,
-                            not math.isnan(glycol_setpoint1),
-                            glycol_setpoint2 is not None,
-                            not math.isnan(glycol_setpoint2),
-                        )
+                if not self.glycol_forecast_active:
+                    # After the setpoints are chosen at noon, monitor
+                    # the system and adjust setpoints if needed.
+                    ambient_temperature = self.weather_model.current_indoor_temperature
+                    if ambient_temperature is not None and not self.check_glycol_setpoint(
+                        ambient_temperature
                     ):
-                        self.glycol_setpoint1 = glycol_setpoint1
-                        self.glycol_setpoint2 = glycol_setpoint2
+                        self.log.debug("Recomputing glycol setpoints.")
+                        glycol_setpoint1, glycol_setpoint2 = self.compute_glycol_setpoints(
+                            ambient_temperature
+                        )
+
+                        if all(
+                            (
+                                glycol_setpoint1 is not None,
+                                not math.isnan(glycol_setpoint1),
+                                glycol_setpoint2 is not None,
+                                not math.isnan(glycol_setpoint2),
+                            )
+                        ):
+                            self.glycol_setpoint1 = glycol_setpoint1
+                            self.glycol_setpoint2 = glycol_setpoint2
 
                 chiller_commands = []
                 if self.glycol_setpoint1 is not None:

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -34,11 +34,12 @@ from lsst.ts import salobj, utils
 from lsst.ts.xml.enums.MTMount import ThermalCommandState
 
 from .cmdwrapper import close_command_tasks, command_wrapper
-from .delay_controller import DelayController, make_delay_policy_from_config
-from .diurnal_timer import DiurnalTimer
+from .delay_controller import DelayController, DelayState, make_delay_policy_from_config
+from .diurnal_timer import DiurnalTimer, get_local_noon_time
 from .dome_model import DomeModel
 from .glass_temperature_model import GlassTemperatureModel
 from .weather_model import WeatherModel
+from .weatherforecast_model import WeatherForecastModel
 
 STD_TIMEOUT = 10  # seconds
 DORMANT_TIME = 100  # Time to wait while sleeping, seconds
@@ -62,6 +63,8 @@ class TmaModel:
     weather_model : `WeatherModel`
         A model for the outdoor weather station, which records the last
         twilight temperature observed while the dome was opened.
+    weatherforecast_model : `WeatherForecastModel`
+        A model representing forecast conditions used for upcoming twilight.
     m1m3ts_remote : `~salobj.Remote`
         The Remote for the MTM1M3TS interface.
     mtmount_remote : `~salobj.Remote`
@@ -83,7 +86,7 @@ class TmaModel:
     top_end_setpoint_delta_closedatnite : `float`
         The difference between the indoor temperature and the top-end
         setpoint during nighttime closed-dome operation.
-    m1m3_setpoint_cadence : `float`
+    m1m3_setpoint_cadence : `float`
         The cadence at which applySetpoints commands should be sent to
         MTM1M3TS (seconds).
     m1m3ts_delay_mode : `dict`
@@ -111,6 +114,9 @@ class TmaModel:
         be used:
          * m1m3ts
          * top_end
+         * forecast
+         * forecast_m1m3ts
+         * forecast_top_end
         Any other values are ignored.
     """
 
@@ -121,6 +127,7 @@ class TmaModel:
         diurnal_timer: DiurnalTimer,
         dome_model: DomeModel,
         weather_model: WeatherModel,
+        weatherforecast_model: WeatherForecastModel,
         glass_temperature_model: GlassTemperatureModel,
         m1m3ts_remote: salobj.Remote,
         mtmount_remote: salobj.Remote,
@@ -138,6 +145,9 @@ class TmaModel:
         fast_cooling_rate: float,
         fan_speed: dict[str, float],
         features_to_disable: list[str],
+        forecast_glycol_setpoint_delta: float | None = None,
+        forecast_heater_setpoint_delta: float | None = None,
+        forecast_top_end_setpoint_delta: float | None = None,
         allow_send: Callable[[], bool] | None = None,
     ) -> None:
         self.log = log
@@ -148,6 +158,7 @@ class TmaModel:
         self.diurnal_timer = diurnal_timer
         self.dome_model = dome_model
         self.weather_model = weather_model
+        self.weatherforecast_model = weatherforecast_model
         self.glass_temperature_model = glass_temperature_model
 
         # Remotes used by command decorators.
@@ -158,6 +169,24 @@ class TmaModel:
         self.glycol_setpoint_delta = glycol_setpoint_delta
         self.heater_setpoint_delta = heater_setpoint_delta
         self.top_end_setpoint_delta = top_end_setpoint_delta
+
+        # Forecast-specific delta overrides
+        # (fall back to standard values when absent):
+        self.forecast_glycol_setpoint_delta = (
+            forecast_glycol_setpoint_delta
+            if forecast_glycol_setpoint_delta is not None
+            else glycol_setpoint_delta
+        )
+        self.forecast_heater_setpoint_delta = (
+            forecast_heater_setpoint_delta
+            if forecast_heater_setpoint_delta is not None
+            else heater_setpoint_delta
+        )
+        self.forecast_top_end_setpoint_delta = (
+            forecast_top_end_setpoint_delta
+            if forecast_top_end_setpoint_delta is not None
+            else top_end_setpoint_delta
+        )
         self.m1m3_extra_delta_closedatnite = m1m3_extra_delta_closedatnite
         self.top_end_setpoint_delta_closedatnite = top_end_setpoint_delta_closedatnite
         self.m1m3_setpoint_cadence = m1m3_setpoint_cadence
@@ -183,6 +212,12 @@ class TmaModel:
 
         self.top_end_task = utils.make_done_future()
         self.top_end_task_warned: bool = False
+        self.twilight_forecast_callback_id: int | None = None
+
+        # True while a forecast-driven setpoint is active. When True,
+        # follow_ess_indoor will not issue new setpoints, giving the forecast
+        # precedence until twilight clears the flag.
+        self.tma_forecast_active: bool = False
 
         # Fan speed configuration
         self.fan_speed_min: float = fan_speed["fan_speed_min"]
@@ -304,6 +339,24 @@ properties:
         while observing.
     type: number
     default: 10.0
+  forecast_glycol_setpoint_delta:
+    type: [number, "null"]
+    default: null
+    description: >-
+      M1M3TS glycol setpoint offset (°C) used when driven by forecast. If absent,
+      glycol_setpoint_delta is used.
+  forecast_heater_setpoint_delta:
+    type: [number, "null"]
+    default: null
+    description: >-
+      M1M3TS heater setpoint offset (°C) used when driven by forecast. If absent,
+      heater_setpoint_delta is used.
+  forecast_top_end_setpoint_delta:
+    type: [number, "null"]
+    default: null
+    description: >-
+      Top-end chiller setpoint offset (°C) used when driven by forecast. If absent,
+      top_end_setpoint_delta is used.
   fan_speed:
     description: Parameters controlling the M1M3TS fan speed response.
     type: object
@@ -317,11 +370,11 @@ properties:
         type: number
         default: 2000.0
       fan_glycol_heater_offset_min:
-        description: Glycol–heater temperature offset (°C) at fan_speed_min.
+        description: Glycol heater temperature offset (°C) at fan_speed_min.
         type: number
         default: -1.0
       fan_glycol_heater_offset_max:
-        description: Glycol–heater temperature offset (°C) at fan_speed_max.
+        description: Glycol heater temperature offset (°C) at fan_speed_max.
         type: number
         default: -4.0
       fan_throttle_turn_on_temp_diff:
@@ -359,7 +412,9 @@ additionalProperties: false
         )
 
     @command_wrapper(
-        remote_attr="m1m3ts_remote", command_attr="cmd_applySetpoints", command_timeout=STD_TIMEOUT
+        remote_attr="m1m3ts_remote",
+        command_attr="cmd_applySetpoints",
+        command_timeout=STD_TIMEOUT,
     )
     async def send_apply_setpoints(
         self,
@@ -373,7 +428,9 @@ additionalProperties: false
         }
 
     @command_wrapper(
-        remote_attr="m1m3ts_remote", command_attr="cmd_heaterFanDemand", command_timeout=STD_TIMEOUT
+        remote_attr="m1m3ts_remote",
+        command_attr="cmd_heaterFanDemand",
+        command_timeout=STD_TIMEOUT,
     )
     async def send_heater_fan_demand(
         self,
@@ -383,7 +440,11 @@ additionalProperties: false
     ) -> dict[str, Any]:
         return {"heaterPWM": heater_pwm, "fanRPM": fan_rpm}
 
-    @command_wrapper(remote_attr="mtmount_remote", command_attr="cmd_setThermal", command_timeout=STD_TIMEOUT)
+    @command_wrapper(
+        remote_attr="mtmount_remote",
+        command_attr="cmd_setThermal",
+        command_timeout=STD_TIMEOUT,
+    )
     async def send_set_thermal(
         self,
         *,
@@ -402,6 +463,7 @@ additionalProperties: false
             await asyncio.gather(
                 self.follow_ess_indoor(),
                 self.apply_setpoint_at_night(),
+                self.monitor_twilight_forecast(),
                 self.wait_for_sunrise(),
             )
         finally:
@@ -412,19 +474,26 @@ additionalProperties: false
                 except asyncio.CancelledError:
                     pass  # Expected
 
+            self.clear_twilight_forecast_callback()
             self.monitor_start_event.clear()
 
         self.log.debug("TmaModel.monitor closing...")
 
-    async def apply_setpoints(self, setpoint: float, *, delta_adjustment: float = 0.0) -> None:
+    async def apply_setpoints(
+        self,
+        setpoint: float,
+        *,
+        delta_adjustment: float = 0.0,
+        glycol_setpoint_delta: float | None = None,
+        heater_setpoint_delta: float | None = None,
+    ) -> None:
+        glycol_delta = self.glycol_setpoint_delta if glycol_setpoint_delta is None else glycol_setpoint_delta
+        heater_delta = self.heater_setpoint_delta if heater_setpoint_delta is None else heater_setpoint_delta
         if "m1m3ts" not in self.features_to_disable:
             glycol_setpoint = (
-                setpoint
-                + self.glycol_setpoint_delta
-                + self.glycol_setpoint_delta_adjustment
-                + delta_adjustment
+                setpoint + glycol_delta + self.glycol_setpoint_delta_adjustment + delta_adjustment
             )
-            heaters_setpoint = setpoint + self.heater_setpoint_delta + delta_adjustment
+            heaters_setpoint = setpoint + heater_delta + delta_adjustment
             self.log.debug(f"Setting MTM1MTS: {glycol_setpoint=:.2f}°C {heaters_setpoint=:.2f}°C")
             await self.send_apply_setpoints(
                 glycol_setpoint=glycol_setpoint,
@@ -433,7 +502,13 @@ additionalProperties: false
 
         self.m1m3_setpoints_are_stale = False
 
-    async def set_fan_speed(self, *, setpoint: float) -> None:
+    async def set_fan_speed(
+        self,
+        *,
+        setpoint: float,
+        glycol_setpoint_delta: float | None = None,
+        heater_setpoint_delta: float | None = None,
+    ) -> None:
         """Compute and send the FCU fan speed based on glass temperature.
 
         The commanded fan speed is determined by the absolute difference
@@ -452,6 +527,8 @@ additionalProperties: false
         setpoint : `float`
             Demand temperature (°C) before applying any offsets.
         """
+        glycol_delta = self.glycol_setpoint_delta if glycol_setpoint_delta is None else glycol_setpoint_delta
+        heater_delta = self.heater_setpoint_delta if heater_setpoint_delta is None else heater_setpoint_delta
         glass_temperature = self.glass_temperature_model.median_temperature
 
         if (
@@ -461,11 +538,11 @@ additionalProperties: false
         ):
             return
 
-        setpoint += self.heater_setpoint_delta
+        control_setpoint = setpoint + heater_delta
         slope = (self.fan_speed_max - self.fan_speed_min) / (
             self.fan_throttle_max_temp_diff - self.fan_throttle_turn_on_temp_diff
         )
-        temperature_difference = abs(glass_temperature - setpoint)
+        temperature_difference = abs(glass_temperature - control_setpoint)
 
         fan_speed = self.fan_speed_min + slope * (
             temperature_difference - self.fan_throttle_turn_on_temp_diff
@@ -478,7 +555,7 @@ additionalProperties: false
             fan_rpm=[fan_rpm] * 96,
         )
 
-        if glass_temperature > setpoint:
+        if glass_temperature > control_setpoint:
             # Adjust glycol offset based on fan speed:
             #   Fan speed of 700 (minimum) -> glycol offset of -1 from heater
             #   Fan speed of 2000 (maximum) -> glycol offset of -4 from heater
@@ -487,12 +564,10 @@ additionalProperties: false
             )
             glycol_offset = glycol_offset_slope * (fan_speed - self.fan_speed_min)
             glycol_offset += self.fan_glycol_heater_offset_min
-            self.glycol_setpoint_delta_adjustment = (
-                self.heater_setpoint_delta + glycol_offset - self.glycol_setpoint_delta
-            )
+            self.glycol_setpoint_delta_adjustment = heater_delta + glycol_offset - glycol_delta
         else:
             self.glycol_setpoint_delta_adjustment = (
-                self.heater_setpoint_delta + self.fan_glycol_heater_offset_min - self.glycol_setpoint_delta
+                heater_delta + self.fan_glycol_heater_offset_min - glycol_delta
             )
 
         self.m1m3_setpoints_are_stale = True
@@ -539,6 +614,17 @@ additionalProperties: false
                 continue
             else:
                 n_failures = 0
+
+            if self.tma_forecast_active and self.delay_controller.state != DelayState.IDLE:
+                self.log.info(
+                    "Discontinuing forecast-driven M1M3TS setpoints because "
+                    f"delay controller state is {self.delay_controller.state.name}."
+                )
+                self.tma_forecast_active = False
+
+            if self.tma_forecast_active:
+                await asyncio.sleep(self.m1m3_setpoint_cadence)
+                continue
 
             if "top_end" not in self.features_to_disable:
                 await self.send_set_thermal(
@@ -710,6 +796,104 @@ additionalProperties: false
 
             await asyncio.sleep(self.m1m3_setpoint_cadence)
 
+    def clear_twilight_forecast_callback(self) -> None:
+        if self.twilight_forecast_callback_id is None:
+            return
+        self.weatherforecast_model.remove_callback(self.twilight_forecast_callback_id)
+        self.twilight_forecast_callback_id = None
+        self.tma_forecast_active = False
+
+    def set_twilight_forecast_callback(self) -> None:
+        self.clear_twilight_forecast_callback()
+        twilight_time = self.diurnal_timer.get_twilight_time(after=Time.now())
+        callback_id = self.weatherforecast_model.add_callback(
+            twilight_time.tai.unix,
+            self.handle_twilight_forecast,
+        )
+        self.twilight_forecast_callback_id = callback_id
+
+    def handle_twilight_forecast(self, predicted_temperature: float) -> None:
+        if not self.diurnal_timer.is_running:
+            return
+        if "forecast" in self.features_to_disable:
+            return
+        if "forecast_m1m3ts" in self.features_to_disable and "forecast_top_end" in self.features_to_disable:
+            return
+        if self.delay_controller.state != DelayState.IDLE:
+            self.log.info(
+                "Skipping forecast-driven M1M3TS setpoints because delay "
+                f"controller state is {self.delay_controller.state.name}."
+            )
+            return
+        self.log.info(
+            f"Applying TMA setpoints based on forecast twilight temperature: {predicted_temperature:.2f}°C"
+        )
+        asyncio.create_task(self.apply_forecast_setpoints(predicted_temperature))
+
+    async def apply_forecast_setpoints(self, predicted_temperature: float) -> None:
+        if self.delay_controller.state != DelayState.IDLE:
+            self.log.info(
+                "Skipping forecast-driven M1M3TS setpoints because delay "
+                f"controller state is {self.delay_controller.state.name}."
+            )
+            self.tma_forecast_active = False
+            return
+        m1m3_forecast_engaged = False
+        if "forecast" not in self.features_to_disable and "forecast_m1m3ts" not in self.features_to_disable:
+            if "m1m3ts" not in self.features_to_disable:
+                if "fanspeed" not in self.features_to_disable:
+                    await self.set_fan_speed(
+                        setpoint=predicted_temperature,
+                        glycol_setpoint_delta=self.forecast_glycol_setpoint_delta,
+                        heater_setpoint_delta=self.forecast_heater_setpoint_delta,
+                    )
+                await self.apply_setpoints(
+                    predicted_temperature,
+                    glycol_setpoint_delta=self.forecast_glycol_setpoint_delta,
+                    heater_setpoint_delta=self.forecast_heater_setpoint_delta,
+                )
+                m1m3_forecast_engaged = True
+            self.m1m3_setpoints_are_stale = False
+
+        if (
+            "forecast" not in self.features_to_disable
+            and "forecast_top_end" not in self.features_to_disable
+            and "top_end" not in self.features_to_disable
+        ):
+            chiller_setpoint = predicted_temperature + self.forecast_top_end_setpoint_delta
+            await self.send_set_thermal(
+                top_end_chiller_setpoint=chiller_setpoint,
+                top_end_chiller_state=ThermalCommandState.ON,
+            )
+
+        self.tma_forecast_active = m1m3_forecast_engaged
+
+    async def monitor_twilight_forecast(self) -> None:
+        """Run forecast callback between noon and evening twilight."""
+        # If started between noon and twilight, begin operating immediately
+        # without waiting for noon.
+        next_noon = get_local_noon_time()
+        if (
+            self.diurnal_timer.is_running
+            and self.diurnal_timer.twilight_time is not None
+            and self.diurnal_timer.twilight_time < next_noon
+        ):
+            self.set_twilight_forecast_callback()
+            async with self.diurnal_timer.twilight_condition:
+                await self.diurnal_timer.twilight_condition.wait()
+            self.clear_twilight_forecast_callback()
+
+        while self.diurnal_timer.is_running:
+            async with self.diurnal_timer.noon_condition:
+                await self.diurnal_timer.noon_condition.wait()
+            if not self.diurnal_timer.is_running:
+                break
+            self.set_twilight_forecast_callback()
+            async with self.diurnal_timer.twilight_condition:
+                await self.diurnal_timer.twilight_condition.wait()
+            self.clear_twilight_forecast_callback()
+
     async def close(self) -> None:
         """Cancel any in-flight command tasks."""
+        self.clear_twilight_forecast_callback()
         await close_command_tasks(self)

--- a/python/lsst/ts/eas/weatherforecast_model.py
+++ b/python/lsst/ts/eas/weatherforecast_model.py
@@ -1,0 +1,123 @@
+# This file is part of ts_eas.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["WeatherForecastModel"]
+
+import logging
+import math
+from typing import Callable
+
+import numpy as np
+
+from lsst.ts import salobj
+
+TEMPERATURE_EPSILON = 0.01
+
+# Expected grid size for the hourlyTrend.temperature data item.
+DELTA_TIME = 5 * 60
+
+
+class WeatherForecastModel:
+    """A class to monitor the Prophet-model based forecast.
+
+    This class provides monitoring of the WeatherForecast CSC
+    hourlyTrend.temperature. It accepts new telemetry for that
+    topic and manages a callback to take action when new forecast
+    data are available.
+
+    Parameters
+    ----------
+    log : `~logging.Logger`
+        A logger for log messages.
+    """
+
+    def __init__(
+        self,
+        *,
+        log: logging.Logger,
+    ) -> None:
+        self.log = log
+
+        self.cached_temperature: None | list[float] = None
+        self.cached_timestamp: None | float = None
+
+        self.callbacks: dict[int, tuple[float, Callable[[float], None]]] = dict()
+        self.next_callback_id: int = 0
+
+    async def hourly_trend_callback(self, hourly_trend: salobj.BaseMsgType) -> None:
+        """Callback for WeatherForecast.tel_hourlyTrend
+
+        This function processes incoming hourlyTrend telmetry. If the
+        temperature item has changed, it calls the needed callbacks.
+
+        Parameters
+        ----------
+        hourly_trend: `~lsst.ts.salobj.BaseMsgType`
+           A newly received hourlyTrend telemetry item.
+        """
+        # Compare the temperature item to the cached value. If it hasn't
+        # changed, take no action.
+        self.log.debug("Received hourlyTrend.")
+        if self.cached_temperature is not None and len(self.cached_temperature) == len(
+            hourly_trend.temperature
+        ):
+            for t1, t2 in zip(hourly_trend.temperature, self.cached_temperature):
+                if math.fabs(t1 - t2) > TEMPERATURE_EPSILON:
+                    break
+            else:
+                return
+
+        # Cache the received telemetry.
+        self.cached_temperature = hourly_trend.temperature
+        self.cached_timestamp = hourly_trend.private_sndStamp
+
+        self.call_callbacks()
+
+    def predict_temperature_at_time(self, time: float) -> float | None:
+        if self.cached_temperature is None or self.cached_timestamp is None:
+            raise RuntimeError("predict_temperature_at_time called with invalid cache")
+
+        # Do an interpolation to get the temperature prediction.
+        index_float = (time - self.cached_timestamp) / DELTA_TIME - 1
+        if index_float < 0 or index_float > len(self.cached_temperature) - 1:
+            return None
+
+        return np.interp(
+            index_float,
+            np.arange(len(self.cached_temperature)),
+            self.cached_temperature,
+        )
+
+    def call_callbacks(self) -> None:
+        for time, callback in self.callbacks.values():
+            prediction = self.predict_temperature_at_time(time)
+            if prediction is None:
+                continue
+            callback(prediction)
+
+    def add_callback(self, time: float, callback: Callable[[float], None]) -> int:
+        callback_id = self.next_callback_id
+        self.next_callback_id += 1
+        self.callbacks[callback_id] = (time, callback)
+        return callback_id
+
+    def remove_callback(self, callback_id: int) -> None:
+        self.callbacks.pop(callback_id, None)

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -25,13 +25,16 @@ import math
 import types
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from typing import NotRequired, TypedDict
 
 import astropy
 import yaml
+from astropy.time import Time, TimeDelta
 
 from lsst.ts import salobj
 from lsst.ts.eas import hvac_model
+from lsst.ts.eas.weatherforecast_model import DELTA_TIME, WeatherForecastModel
 from lsst.ts.xml.enums.HVAC import DeviceId
 
 STD_TIMEOUT = 10
@@ -72,9 +75,14 @@ class DiurnalTimerMock:
         self._night = night
         self.noon_condition = asyncio.Condition()
         self.sunrise_condition = asyncio.Condition()
+        self.twilight_condition = asyncio.Condition()
+        self.twilight_time: Time | None = None
 
     def is_night(self, time: astropy.time.Time) -> bool:
         return self._night
+
+    def get_twilight_time(self, *, after: Time) -> Time:
+        return after + TimeDelta(45 * 60, format="sec")
 
     async def stop(self) -> None:
         self.is_running = False
@@ -82,6 +90,8 @@ class DiurnalTimerMock:
             self.noon_condition.notify_all()
         async with self.sunrise_condition:
             self.sunrise_condition.notify_all()
+        async with self.twilight_condition:
+            self.twilight_condition.notify_all()
 
 
 async def signal_noon(timer: DiurnalTimerMock) -> None:
@@ -103,6 +113,20 @@ async def signal_sunrise(timer: DiurnalTimerMock) -> None:
         await asyncio.sleep(STD_SLEEP)
         async with timer.sunrise_condition:
             timer.sunrise_condition.notify_all()
+        await asyncio.sleep(STD_SLEEP)
+        await timer.stop()
+
+    await asyncio.wait_for(
+        asyncio.create_task(signal_coroutine()),
+        timeout=STD_TIMEOUT,
+    )
+
+
+async def signal_twilight(timer: DiurnalTimerMock) -> None:
+    async def signal_coroutine() -> None:
+        await asyncio.sleep(STD_SLEEP)
+        async with timer.twilight_condition:
+            timer.twilight_condition.notify_all()
         await asyncio.sleep(STD_SLEEP)
         await timer.stop()
 
@@ -183,6 +207,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             nightly_minimum_temperature=6.0,
             nightly_maximum_indoor_dew_point=-10.0,
         )
+        self.weatherforecast = WeatherForecastModel(log=self.log)
 
     def make_model(self, **overrides: float | list[int] | list[str] | None) -> hvac_model.HvacModel:
         params = dict(
@@ -208,6 +233,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             diurnal_timer=self.diurnal,
             dome_model=self.dome,
             weather_model=self.weather,
+            weatherforecast_model=self.weatherforecast,
             hvac_remote=self.remote,
             **params,
         )
@@ -251,7 +277,10 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         # Nominal average would be 7.5, but dew point 7.625 + margin 1 = 8.625
         #   --> average raised to 8.625.
         s1, s2 = model.compute_glycol_setpoints(self.weather.current_indoor_temperature)
-        self.assertAlmostEqual((s1 + s2) / 2.0, 8.625, places=6)
+        assert s1 is not None
+        assert s2 is not None
+        setpoints_avg = (s1 + s2) / 2.0
+        self.assertAlmostEqual(setpoints_avg, 8.625, places=6)
 
     def test_absolute_minimum_enforced(self) -> None:
         """Setpoints should not drop below the configured absolute minimum."""
@@ -764,6 +793,118 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             with self.subTest(config_path=filename):
                 validated = validator.validate(vars(self.get_config(filename)))
                 self.assertEqual(validated["ahu_control"], expected_ahu_control)
+
+    async def test_forecast_ahu_applies_setpoint(self) -> None:
+        """Forecast-based AHU setpoints should be applied."""
+        self.diurnal.is_running = True
+        model = self.make_model(ahu_setpoint_delta=-1.0, setpoint_lower_limit=6.0)
+
+        model.handle_twilight_forecast(7.0)
+        await asyncio.sleep(STD_SLEEP)
+
+        expected = 6.0
+        for ahu in (
+            DeviceId.airHandlingUnit01Dome,
+            DeviceId.airHandlingUnit02Dome,
+            DeviceId.airHandlingUnit03Dome,
+            DeviceId.airHandlingUnit04Dome,
+        ):
+            setpoint = self.hvac.ahu_setpoints.get(ahu)
+            assert setpoint is not None
+            self.assertAlmostEqual(setpoint, expected, places=6)
+
+        self.hvac.ahu_setpoints.clear()
+
+    async def test_forecast_ahu_respects_ahu_control_subset(self) -> None:
+        """Forecast AHU setpoints should only target configured AHUs."""
+        self.diurnal.is_running = True
+        model = self.make_model(
+            ahu_control=[2, 4],
+            ahu_setpoint_delta=0.0,
+            setpoint_lower_limit=-100.0,
+        )
+
+        model.handle_twilight_forecast(7.0)
+        await asyncio.sleep(STD_SLEEP)
+
+        self.assertDictEqual(
+            self.hvac.ahu_setpoints,
+            {
+                DeviceId.airHandlingUnit02Dome: 7.0,
+                DeviceId.airHandlingUnit04Dome: 7.0,
+            },
+        )
+
+        self.hvac.ahu_setpoints.clear()
+
+    async def test_forecast_ahu_disabled_flags(self) -> None:
+        """Forecast-based AHU setpoints should honor disable flags."""
+        for feature in ("forecast_ahu", "forecast"):
+            with self.subTest(feature=feature):
+                self.diurnal.is_running = True
+                model = self.make_model(features_to_disable=[feature])
+
+                self.hvac.ahu_setpoints.clear()
+                model.handle_twilight_forecast(10.0)
+                await asyncio.sleep(STD_SLEEP)
+
+                self.assertDictEqual(self.hvac.ahu_setpoints, {})
+
+        self.hvac.ahu_setpoints.clear()
+
+    async def test_monitor_twilight_forecast_applies_setpoint(self) -> None:
+        """Forecast callback should apply AHU setpoints during the window."""
+        self.diurnal.is_running = True
+        model = self.make_model(ahu_setpoint_delta=0.0, setpoint_lower_limit=-100.0)
+
+        task = asyncio.create_task(model.monitor_twilight_forecast())
+
+        # Wait for task to start waiting for noon.
+        await asyncio.sleep(STD_SLEEP)
+
+        # Signal that it's noon.
+        async with self.diurnal.noon_condition:
+            timestamp = Time.now()
+            self.diurnal.noon_condition.notify_all()
+        await asyncio.sleep(STD_SLEEP)
+
+        target_time = self.diurnal.get_twilight_time(after=timestamp)  # Time of twilight
+        timestamp = timestamp.unix  # Convert to unix epoch
+
+        def prediction(time: float) -> float:
+            return 10.0 + (time - (timestamp + DELTA_TIME)) / DELTA_TIME
+
+        temperatures = [prediction(timestamp + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry = SimpleNamespace(
+            temperature=temperatures,
+            private_sndStamp=timestamp,
+        )
+        await self.weatherforecast.hourly_trend_callback(telemetry)
+        await asyncio.sleep(STD_SLEEP)
+
+        expected = prediction(target_time.unix)
+        for ahu in (
+            DeviceId.airHandlingUnit01Dome,
+            DeviceId.airHandlingUnit02Dome,
+            DeviceId.airHandlingUnit03Dome,
+            DeviceId.airHandlingUnit04Dome,
+        ):
+            setpoint = self.hvac.ahu_setpoints.get(ahu)
+            assert setpoint is not None
+
+            # There's a small difference between the setpoint and
+            # expected because of a small time difference between
+            # Time.now call in the test and the call when the
+            # callback is scheduled in WeatherForecastModel.
+            #
+            # We could patch Time.now but it's easier just
+            # to make our assertAlmostEqual a bit more permissive.
+            self.assertAlmostEqual(setpoint, expected, places=4)
+
+        await signal_twilight(self.diurnal)
+        await asyncio.wait_for(task, timeout=STD_TIMEOUT)
+
+        self.hvac.ahu_setpoints.clear()
 
     def basic_make_csc(
         self,

--- a/tests/test_tma.py
+++ b/tests/test_tma.py
@@ -28,6 +28,7 @@ from collections import deque
 from types import SimpleNamespace
 
 from lsst.ts import eas, salobj
+from lsst.ts.eas.weatherforecast_model import WeatherForecastModel
 
 STD_TIMEOUT = 60
 STD_SLEEP = 0.5
@@ -135,6 +136,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 dome_model=self.dome_model,
                 glass_temperature_model=SimpleNamespace(median_temperature=0.0),
                 weather_model=self.weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
                 m1m3ts_remote=m1m3ts_remote,
                 mtmount_remote=mtmount_remote,
                 glycol_setpoint_delta=model_args["glycol_setpoint_delta"],
@@ -142,7 +144,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 top_end_setpoint_delta=model_args["top_end_setpoint_delta"],
                 m1m3_extra_delta_closedatnite=model_args.get("m1m3_extra_delta_closedatnite", 0.0),
                 top_end_setpoint_delta_closedatnite=model_args.get(
-                    "top_end_setpoint_delta_closedatnite", model_args["top_end_setpoint_delta"]
+                    "top_end_setpoint_delta_closedatnite",
+                    model_args["top_end_setpoint_delta"],
                 ),
                 m1m3_setpoint_cadence=cadence,
                 setpoint_deadband_heating=0,
@@ -418,6 +421,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 dome_model=dome_model,
                 glass_temperature_model=SimpleNamespace(median_temperature=0.0),
                 weather_model=weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
                 m1m3ts_remote=m1m3ts_remote,
                 mtmount_remote=mtmount_remote,
                 glycol_setpoint_delta=-2,
@@ -486,6 +490,182 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 - tma_model.glycol_setpoint_delta,
             )
 
+    async def test_forecast_setpoints_use_forecast_fan_and_glycol_adjustment(
+        self,
+    ) -> None:
+        """Forecast control should use forecast deltas in M1M3 feedback."""
+        diurnal_timer = eas.diurnal_timer.DiurnalTimer()
+        diurnal_timer.is_running = True
+
+        weather_model = WeatherModelMock(self.last_twilight_temperature)
+        dome_model = DomeModelMock(is_closed=True)
+
+        async with (
+            M1M3TSMock() as mock_m1m3ts,
+            salobj.Remote(name="MTM1M3TS", domain=mock_m1m3ts.domain) as m1m3ts_remote,
+            salobj.Remote(name="MTMount", domain=mock_m1m3ts.domain) as mtmount_remote,
+        ):
+            tma_model = eas.tma_model.TmaModel(
+                log=mock_m1m3ts.log,
+                diurnal_timer=diurnal_timer,
+                dome_model=dome_model,
+                glass_temperature_model=SimpleNamespace(median_temperature=2.0),
+                weather_model=weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
+                m1m3ts_remote=m1m3ts_remote,
+                mtmount_remote=mtmount_remote,
+                glycol_setpoint_delta=-2.0,
+                heater_setpoint_delta=-1.0,
+                top_end_setpoint_delta=-1.0,
+                m1m3_extra_delta_closedatnite=0.0,
+                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_setpoint_cadence=10,
+                setpoint_deadband_heating=0,
+                setpoint_deadband_cooling=0,
+                maximum_heating_rate=100,
+                slow_cooling_rate=1,
+                fast_cooling_rate=10,
+                fan_speed={
+                    "fan_speed_min": 700.0,
+                    "fan_speed_max": 2000.0,
+                    "fan_glycol_heater_offset_min": -1.0,
+                    "fan_glycol_heater_offset_max": -4.0,
+                    "fan_throttle_turn_on_temp_diff": 0.0,
+                    "fan_throttle_max_temp_diff": 1.0,
+                },
+                m1m3ts_delay_mode={"mode": "time_delay", "delay": 0.0},
+                features_to_disable=[],
+                forecast_glycol_setpoint_delta=-3.0,
+                forecast_heater_setpoint_delta=-0.5,
+            )
+
+            await tma_model.apply_forecast_setpoints(predicted_temperature=0.0)
+            await asyncio.sleep(STD_SLEEP)
+
+            expected_heater_setpoint = -0.5
+            expected_glycol_setpoint = expected_heater_setpoint + tma_model.fan_glycol_heater_offset_max
+
+            self.assertEqual(mock_m1m3ts.heater_setpoint, expected_heater_setpoint)
+            self.assertEqual(mock_m1m3ts.glycol_setpoint, expected_glycol_setpoint)
+            self.assertEqual(mock_m1m3ts.fan_rpm, [int(0.1 * tma_model.fan_speed_max)] * 96)
+
+    async def test_forecast_setpoints_require_idle_delay_controller(self) -> None:
+        """Forecast control should be skipped unless delay is idle."""
+        diurnal_timer = eas.diurnal_timer.DiurnalTimer()
+        diurnal_timer.is_running = True
+
+        weather_model = WeatherModelMock(self.last_twilight_temperature)
+        dome_model = DomeModelMock(is_closed=True)
+
+        async with (
+            M1M3TSMock() as mock_m1m3ts,
+            salobj.Remote(name="MTM1M3TS", domain=mock_m1m3ts.domain) as m1m3ts_remote,
+            salobj.Remote(name="MTMount", domain=mock_m1m3ts.domain) as mtmount_remote,
+        ):
+            tma_model = eas.tma_model.TmaModel(
+                log=mock_m1m3ts.log,
+                diurnal_timer=diurnal_timer,
+                dome_model=dome_model,
+                glass_temperature_model=SimpleNamespace(median_temperature=2.0),
+                weather_model=weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
+                m1m3ts_remote=m1m3ts_remote,
+                mtmount_remote=mtmount_remote,
+                glycol_setpoint_delta=-2.0,
+                heater_setpoint_delta=-1.0,
+                top_end_setpoint_delta=-1.0,
+                m1m3_extra_delta_closedatnite=0.0,
+                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_setpoint_cadence=10,
+                setpoint_deadband_heating=0,
+                setpoint_deadband_cooling=0,
+                maximum_heating_rate=100,
+                slow_cooling_rate=1,
+                fast_cooling_rate=10,
+                fan_speed={
+                    "fan_speed_min": 700.0,
+                    "fan_speed_max": 2000.0,
+                    "fan_glycol_heater_offset_min": -1.0,
+                    "fan_glycol_heater_offset_max": -4.0,
+                    "fan_throttle_turn_on_temp_diff": 0.0,
+                    "fan_throttle_max_temp_diff": 1.0,
+                },
+                m1m3ts_delay_mode={"mode": "time_delay", "delay": 0.0},
+                features_to_disable=[],
+                forecast_glycol_setpoint_delta=-3.0,
+                forecast_heater_setpoint_delta=-0.5,
+            )
+
+            tma_model.delay_controller.state = eas.delay_controller.DelayState.WAITING
+            tma_model.tma_forecast_active = True
+
+            await tma_model.apply_forecast_setpoints(predicted_temperature=0.0)
+            await asyncio.sleep(STD_SLEEP)
+
+            self.assertIsNone(mock_m1m3ts.heater_setpoint)
+            self.assertIsNone(mock_m1m3ts.glycol_setpoint)
+            self.assertIsNone(mock_m1m3ts.fan_rpm)
+            self.assertFalse(tma_model.tma_forecast_active)
+
+    async def test_top_end_only_forecast_does_not_activate_m1m3_forecast_state(
+        self,
+    ) -> None:
+        """Top-end-only forecast should not suppress normal M1M3TS tracking."""
+        diurnal_timer = eas.diurnal_timer.DiurnalTimer()
+        diurnal_timer.is_running = True
+
+        weather_model = WeatherModelMock(self.last_twilight_temperature)
+        dome_model = DomeModelMock(is_closed=True)
+
+        async with (
+            M1M3TSMock() as mock_m1m3ts,
+            MTMountMock() as mock_mtmount,
+            salobj.Remote(name="MTM1M3TS", domain=mock_m1m3ts.domain) as m1m3ts_remote,
+            salobj.Remote(name="MTMount", domain=mock_m1m3ts.domain) as mtmount_remote,
+        ):
+            await mock_mtmount.evt_summaryState.set_write(summaryState=salobj.State.ENABLED)
+
+            tma_model = eas.tma_model.TmaModel(
+                log=mock_m1m3ts.log,
+                diurnal_timer=diurnal_timer,
+                dome_model=dome_model,
+                glass_temperature_model=SimpleNamespace(median_temperature=2.0),
+                weather_model=weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
+                m1m3ts_remote=m1m3ts_remote,
+                mtmount_remote=mtmount_remote,
+                glycol_setpoint_delta=-2.0,
+                heater_setpoint_delta=-1.0,
+                top_end_setpoint_delta=-1.0,
+                m1m3_extra_delta_closedatnite=0.0,
+                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_setpoint_cadence=10,
+                setpoint_deadband_heating=0,
+                setpoint_deadband_cooling=0,
+                maximum_heating_rate=100,
+                slow_cooling_rate=1,
+                fast_cooling_rate=10,
+                fan_speed={
+                    "fan_speed_min": 700.0,
+                    "fan_speed_max": 2000.0,
+                    "fan_glycol_heater_offset_min": -1.0,
+                    "fan_glycol_heater_offset_max": -4.0,
+                    "fan_throttle_turn_on_temp_diff": 0.0,
+                    "fan_throttle_max_temp_diff": 1.0,
+                },
+                m1m3ts_delay_mode={"mode": "time_delay", "delay": 0.0},
+                features_to_disable=["forecast_m1m3ts"],
+                forecast_top_end_setpoint_delta=-0.25,
+            )
+
+            await tma_model.apply_forecast_setpoints(predicted_temperature=1.5)
+            await asyncio.sleep(STD_SLEEP)
+
+            self.assertIsNone(mock_m1m3ts.heater_setpoint)
+            self.assertIsNone(mock_m1m3ts.glycol_setpoint)
+            self.assertFalse(tma_model.tma_forecast_active)
+            self.assertAlmostEqual(mock_mtmount.top_end_setpoint, 1.25)
+
     async def test_delay_policy_time_delay(self) -> None:
         """Delay policy should gate tracking until the time delay elapses."""
         cadence = 0.05
@@ -512,6 +692,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 dome_model=dome_model,
                 glass_temperature_model=SimpleNamespace(median_temperature=0.0),
                 weather_model=weather_model,
+                weatherforecast_model=WeatherForecastModel(log=mock_m1m3ts.log),
                 m1m3ts_remote=m1m3ts_remote,
                 mtmount_remote=mtmount_remote,
                 glycol_setpoint_delta=-2,

--- a/tests/test_weatherforecast_model.py
+++ b/tests/test_weatherforecast_model.py
@@ -1,0 +1,156 @@
+# This file is part of ts_eas.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import unittest
+from types import SimpleNamespace
+
+from lsst.ts.eas.weatherforecast_model import DELTA_TIME, WeatherForecastModel
+
+# Starting timestamp for the tests (sec)
+timestamp0 = 1000.0
+
+
+def _prediction(time: float) -> float:
+    """A dummy forecast that starts at 9.0°C at timestamp0 and increases at
+    the rate of 1.0°C every 5 minutes.
+
+    Parameters
+    ----------
+    time : `float`
+        The time (TAI seconds) of the desired forecast data point.
+
+    Returns
+    -------
+    `float`
+        Forecast temperature in °C.
+    """
+    m = 1.0 / 300.0
+    b = 9.0 - m * timestamp0
+
+    return m * time + b
+
+
+class CallbackRecorder:
+    """Collect callback values for assertions."""
+
+    def __init__(self) -> None:
+        self.values: list[float] = []
+
+    def __call__(self, value: float) -> None:
+        self.values.append(value)
+
+
+class TestWeatherForecastModel(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.log = logging.getLogger("weatherforecast")
+        self.model = WeatherForecastModel(log=self.log)
+
+    async def test_single_callback_lifecycle(self) -> None:
+        """The forecast model should call a callback and respect removal."""
+        callback = CallbackRecorder()
+
+        target_time = timestamp0 + 47.5 * 60
+
+        callback_id = self.model.add_callback(target_time, callback)
+
+        temperatures = [_prediction(timestamp0 + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry = SimpleNamespace(
+            temperature=temperatures,
+            private_sndStamp=timestamp0,
+        )
+
+        await self.model.hourly_trend_callback(telemetry)
+        self.assertEqual(len(callback.values), 1)
+        expected = _prediction(target_time)
+        self.assertAlmostEqual(callback.values[0], expected)
+
+        self.model.remove_callback(callback_id)
+        self.assertDictEqual(self.model.callbacks, {})
+
+        timestamp2 = timestamp0 + DELTA_TIME
+        temperatures2 = [_prediction(timestamp2 + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry2 = SimpleNamespace(
+            temperature=temperatures2,
+            private_sndStamp=timestamp2,
+        )
+        await self.model.hourly_trend_callback(telemetry2)
+        self.assertEqual(len(callback.values), 1)
+
+    async def test_two_callbacks_lifecycle(self) -> None:
+        """The forecast model should call two callbacks and respect removal."""
+        callback_1 = CallbackRecorder()
+        callback_2 = CallbackRecorder()
+
+        target_time_1 = timestamp0 + 46 * 60
+        target_time_2 = timestamp0 + 56 * 60
+
+        callback_id_1 = self.model.add_callback(target_time_1, callback_1)
+        callback_id_2 = self.model.add_callback(target_time_2, callback_2)
+
+        temperatures = [_prediction(timestamp0 + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry = SimpleNamespace(
+            temperature=temperatures,
+            private_sndStamp=timestamp0,
+        )
+
+        await self.model.hourly_trend_callback(telemetry)
+        self.assertEqual(len(callback_1.values), 1)
+        self.assertEqual(len(callback_2.values), 1)
+        expected_1 = _prediction(target_time_1)
+        expected_2 = _prediction(target_time_2)
+        self.assertAlmostEqual(callback_1.values[0], expected_1)
+        self.assertAlmostEqual(callback_2.values[0], expected_2)
+
+        self.model.remove_callback(callback_id_1)
+        self.model.remove_callback(callback_id_2)
+        self.assertDictEqual(self.model.callbacks, {})
+
+        timestamp2 = timestamp0 + DELTA_TIME
+        temperatures2 = [_prediction(timestamp2 + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry2 = SimpleNamespace(
+            temperature=temperatures2,
+            private_sndStamp=timestamp2,
+        )
+        await self.model.hourly_trend_callback(telemetry2)
+        self.assertEqual(len(callback_1.values), 1)
+        self.assertEqual(len(callback_2.values), 1)
+
+    async def test_callback_not_called_when_target_in_past(self) -> None:
+        """The model should not call a callback when target time has passed."""
+        callback = CallbackRecorder()
+
+        target_time = timestamp0 - 60.0
+        self.model.add_callback(target_time, callback)
+
+        temperatures = [_prediction(timestamp0 + (idx + 1) * DELTA_TIME) for idx in range(12)]
+        telemetry = SimpleNamespace(
+            temperature=temperatures,
+            private_sndStamp=timestamp0,
+        )
+
+        await self.model.hourly_trend_callback(telemetry)
+        self.assertEqual(len(callback.values), 0)
+
+    async def test_remove_missing_callback_noop(self) -> None:
+        """Removing a non-existent callback should be a no-op."""
+        self.model.remove_callback(9999)
+        self.assertDictEqual(self.model.callbacks, {})


### PR DESCRIPTION
* Adds WeatherForecast integration to EAS and uses forecast hourlyTrend telemetry to drive pre-twilight setpoints for both HVAC and TMA.
* WeatherForecast telemetry is used to determine setpoints for TMA (and M1M3TS fan speed) and HVAC AHUs from noon until dome open or twilight, whichever comes first.