### PR TITLE
OSW-1555: Add daytime control of louvers.

### DIFF
--- a/doc/news/OSW-1555.feature.rst
+++ b/doc/news/OSW-1555.feature.rst
@@ -1,0 +1,1 @@
+Added daytime control of louvers.

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -59,6 +59,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             * `m1m3ts`: MTM1M3TS setpoints will not be applied.
             * `closedatnite`: Nighttime closed-dome setpoint control will not run.
             * `require_dome_open`: functionality will operate even when the dome is closed.
+            * `day_louvers`: louver positions will not be adjusted based on sun position during the day.
         type: array
         items:
           type: string
@@ -75,6 +76,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             - m1m3ts
             - closedatnite
             - require_dome_open
+            - day_louvers
       twilight_definition:
         description: >
           Definition of twilight. Can be a number (in degrees) between -90 and 0, corresponding

--- a/python/lsst/ts/eas/diurnal_timer.py
+++ b/python/lsst/ts/eas/diurnal_timer.py
@@ -31,7 +31,7 @@ from astropy.utils import iers
 from astropy.utils.iers import conf as iers_conf
 from scipy.optimize import brentq
 
-__all__ = ["DiurnalTimer"]
+__all__ = ["DiurnalTimer", "OBSERVATORY_LOCATION"]
 
 iers_conf.auto_download = False
 iers_conf.iers_degraded_accuracy = "ignore"

--- a/python/lsst/ts/eas/dome_model.py
+++ b/python/lsst/ts/eas/dome_model.py
@@ -24,27 +24,69 @@ __all__ = ["DomeModel"]
 import asyncio
 import logging
 from collections import deque
+from typing import Any, Callable
 
 import yaml
+from astropy import units as u
+from astropy.coordinates import AltAz, get_sun
+from astropy.time import Time
 
 from lsst.ts import salobj, utils
+from lsst.ts.xml.tables.mtdome import LouverTable
 
-DORMANT_TIME = 300  # Time to wait while sleeping, seconds
+from .cmdwrapper import close_command_tasks, command_wrapper
+from .diurnal_timer import OBSERVATORY_LOCATION
+
+DORMANT_TIME = 30  # Time to wait while sleeping, seconds
 MAX_TELEMETRY_AGE = 300  # Time at which apertureShutter telemetry expires, seconds
+
+# Minimum dome-azimuth change (degrees) that retriggers louver adjustment
+# from the azimuth callback.
+AZIMUTH_CHANGE_THRESHOLD = 0.1
+
+# Atmospheric pressure used in the sun-altitude refraction correction.
+SUN_ALTITUDE_PRESSURE = 700 * u.hPa
+
+
+# Number of degrees in a complete circle.
+CIRCLE = 360.0
 
 
 class DomeModel:
     """A model for MTDome.
 
-    Track whether and when the dome has been opened.
+    Track whether and when the dome has been opened, and adjust louver
+    positions based on the sun azimuth.
 
     Parameters
-    ---------
+    ----------
     log : `~logging.Logger`
         A logger for log messages.
     dome_open_threshold : `float`
         Percent opening of a dome slit or louver beyond which the dome is
         considered "open."
+    louver_sun_angle : `float`
+        Minimum angular separation (degrees) between a louver's azimuth and
+        the sun's azimuth at which the louver is considered to be facing the
+        sun.
+    louver_exposed_command : `float`
+        Commanded percent-open position for a louver that faces the sun.
+    louver_shaded_command : `float`
+        Commanded percent-open position for a louver that does not face the
+        sun.
+    sun_altitude_threshold : `float`
+        Sun altitude (degrees) above which louver positions are adjusted
+        based on sun azimuth.
+    dome_remote : `~lsst.ts.salobj.Remote`
+        SAL remote for the MTDome CSC. Used to send louver commands.
+    features_to_disable : `list` [`str`]
+        List of feature names to disable. If ``"day_louvers"`` is present,
+        sun position is not computed and louvers are not adjusted during the
+        day.
+    allow_send : `Callable` [[], `bool`] | None, optional
+        Callable that returns ``True`` when commands may be sent (i.e., when
+        EAS is in the ENABLED state). If ``None``, commands are always
+        permitted.
     """
 
     def __init__(
@@ -52,6 +94,13 @@ class DomeModel:
         *,
         log: logging.Logger,
         dome_open_threshold: float,
+        louver_sun_angle: float,
+        louver_exposed_command: float,
+        louver_shaded_command: float,
+        sun_altitude_threshold: float,
+        dome_remote: salobj.Remote,
+        features_to_disable: list[str],
+        allow_send: Callable[[], bool] | None = None,
     ) -> None:
         self.monitor_start_event = asyncio.Event()
 
@@ -61,26 +110,69 @@ class DomeModel:
         # Most recent tel_louvers
         self.louvers_telemetry: salobj.BaseMsgType | None = None
 
+        # Most recent actual azimuth of dome (degrees east of north)
+        self.dome_azimuth: float | None = None
+
+        # Minimum angle between louver azimuth and sun azimuth (degrees)
+        # at which a louver is considered to be "facing" the sun.
+        self.louver_sun_angle: float = louver_sun_angle
+
+        # Desired command position for a louver facing the sun.
+        self.louver_exposed_command: float = louver_exposed_command
+
+        # Desired command position for a louver that is not facing the sun.
+        self.louver_shaded_command: float = louver_shaded_command
+
+        # Sun altitude (degrees) above which louvers are adjusted.
+        self.sun_altitude_threshold: float = sun_altitude_threshold
+
         self.on_open: deque[asyncio.Event] = deque()
         self.was_closed: bool | None = None
 
         self.log = log
         self.dome_open_threshold = dome_open_threshold
+        self.dome_remote = dome_remote
+        self.features_to_disable = features_to_disable
+        self.allow_send = allow_send
 
     @classmethod
     def get_config_schema(cls) -> str:
         return yaml.safe_load(
             """
 $schema: http://json-schema.org/draft-07/schema#
-description: Schema for TMA EAS configuration.
+description: Schema for Dome EAS configuration.
 type: object
 properties:
   dome_open_threshold:
     description: Percent opening of a dome slit or louver beyond which the dome is considered "open."
     type: number
     default: 50.0
+  louver_sun_angle:
+    description: >-
+      Minimum angular separation (degrees) between a louver's azimuth and the
+      sun's azimuth at which the louver is considered to be facing the sun.
+    type: number
+    default: 60.0
+  louver_exposed_command:
+    description: Commanded percent-open position for a louver that faces the sun.
+    type: number
+    default: 50.0
+  louver_shaded_command:
+    description: Commanded percent-open position for a louver that does not face the sun.
+    type: number
+    default: 100.0
+  sun_altitude_threshold:
+    description: >-
+      Sun altitude (degrees) above which louver positions are adjusted based
+      on sun azimuth.
+    type: number
+    default: -1.0
 required:
   - dome_open_threshold
+  - louver_sun_angle
+  - louver_exposed_command
+  - louver_shaded_command
+additionalProperties: false
 """
         )
 
@@ -101,6 +193,27 @@ required:
     async def louvers_callback(self, louvers_telemetry: salobj.BaseMsgType) -> None:
         self.louvers_telemetry = louvers_telemetry
         self.refresh_telemetry()
+
+    async def azimuth_callback(self, azimuth_telemetry: salobj.BaseMsgType) -> None:
+        """Callback for MTDome.tel_azimuth.
+
+        Data from this telemetry item is used to track the current dome
+        azimuth, which is required to compute per-louver sun angles. When
+        the dome azimuth changes by more than `AZIMUTH_CHANGE_THRESHOLD`
+        (or is being read for the first time), louver positions are
+        recomputed against the current sun position.
+
+        Parameters
+        ----------
+        azimuth_telemetry : `~lsst.ts.salobj.BaseMsgType`
+            A newly received azimuth telemetry item.
+        """
+        new_azimuth = azimuth_telemetry.positionActual
+        previous_azimuth = self.dome_azimuth
+        self.dome_azimuth = new_azimuth
+
+        if previous_azimuth is None or abs(new_azimuth - previous_azimuth) > AZIMUTH_CHANGE_THRESHOLD:
+            await self.update_louvers_for_sun()
 
     def refresh_telemetry(self) -> None:
         is_closed = self.is_closed
@@ -153,3 +266,109 @@ required:
         )
 
         return shutters_closed and louvers_closed
+
+    @command_wrapper(remote_attr="dome_remote", command_attr="cmd_setLouvers")
+    async def set_louvers(self, position: list[float]) -> dict[str, Any] | None:
+        """Send a setLouvers command to the MTDome CSC.
+
+        Parameters
+        ----------
+        position : `list` [`float`]
+            Desired percent-open position for each of the 34 louvers.
+            A value of 0 is fully closed, 100 is fully open, and -1
+            means do not move the louver.
+
+        Returns
+        -------
+        `dict` [`str`, `Any`] | None
+            Keyword arguments forwarded to ``cmd_setLouvers.set_start``.
+        """
+        return {"position": position}
+
+    async def adjust_louvers(self, sun_azimuth: float) -> None:
+        """Adjust positions of louvers.
+
+        If a louver is actively being commanded (`positionCommanded` >= 0) then
+        the commanded position of the louver should be adjusted based on the
+        azimuth of the sun: if the louvers face the sun (within
+        `louver_sun_angle`) its commanded position should be set to
+        `exposed_lover_command`. If the louver does not face the sun, its
+        commanded position should be set to `shaded_louver_command` If the
+        louver is not commanded, it should remain uncommanded.
+
+        Parameters
+        ----------
+        sun_azimuth : `float`
+            Current sun azimuth in degrees, north = 0, east = 90.
+        """
+        if self.louvers_telemetry is None or self.dome_azimuth is None:
+            return
+
+        louver_azimuth = [(self.dome_azimuth + louver.azimuth) % CIRCLE for louver in LouverTable]
+        sun_distance = [
+            min((sun_azimuth - az) % CIRCLE, (az - sun_azimuth) % CIRCLE) for az in louver_azimuth
+        ]
+        louver_command = [
+            (
+                -1.0
+                if cmd < 0
+                else self.louver_exposed_command
+                if sd < self.louver_sun_angle
+                else self.louver_shaded_command
+            )
+            for cmd, sd in zip(self.louvers_telemetry.positionCommanded[: len(LouverTable)], sun_distance)
+        ]
+        await self.set_louvers(position=louver_command)
+
+    async def update_louvers_for_sun(self) -> None:
+        """Adjust louvers against the current sun position.
+
+        Computes the sun's current altitude and azimuth at the observatory
+        location and, if the sun is above `sun_altitude_threshold` and the
+        ``day_louvers`` feature is not disabled, calls `adjust_louvers`
+        with the sun azimuth.
+        """
+        if "day_louvers" in self.features_to_disable:
+            return
+
+        t = Time.now()
+        sun = get_sun(t)
+        altaz = sun.transform_to(
+            AltAz(
+                obstime=t,
+                location=OBSERVATORY_LOCATION,
+                pressure=SUN_ALTITUDE_PRESSURE,
+            )
+        )
+        if altaz.alt.deg > self.sun_altitude_threshold:
+            await self.adjust_louvers(altaz.az.deg)
+
+    async def monitor(self) -> None:
+        """Monitor the sun position and adjust louvers accordingly.
+
+        Periodically checks whether the sun is above the horizon. When it
+        is, `adjust_louvers` is called with the current sun azimuth so
+        that each active louver is commanded to an appropriate position.
+
+        Signals `monitor_start_event` before entering the polling loop so
+        that the EAS CSC can synchronize startup across all monitor tasks.
+        """
+        self.log.debug("DomeModel.monitor")
+
+        self.monitor_start_event.set()
+        try:
+            while True:
+                try:
+                    await self.update_louvers_for_sun()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    self.log.exception("In DomeModel louver control loop.")
+
+                await asyncio.sleep(DORMANT_TIME)
+        finally:
+            self.monitor_start_event.clear()
+
+    async def close(self) -> None:
+        """Cancel any in-flight command tasks."""
+        await close_command_tasks(self)

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -125,8 +125,7 @@ class EasCsc(salobj.ConfigurableCsc):
         self.dome_remote = salobj.Remote(
             domain=self.domain,
             name="MTDome",
-            readonly=True,
-            include=["apertureShutter", "louvers", "summaryState"],
+            include=["apertureShutter", "azimuth", "louvers", "summaryState"],
         )
         self.ess_ts1_remote = salobj.Remote(
             domain=self.domain,
@@ -214,6 +213,8 @@ class EasCsc(salobj.ConfigurableCsc):
     async def close_tasks(self) -> None:
         """Stop active tasks."""
         await self.shutdown_health_monitor()
+        if self.dome_model is not None:
+            await self.dome_model.close()
         if self.hvac_model is not None:
             await self.hvac_model.close()
         if self.tma_model is not None:
@@ -296,7 +297,13 @@ class EasCsc(salobj.ConfigurableCsc):
             validator = salobj.DefaultingValidator(schema)
             setattr(config, attr, validator.validate(getattr(config, attr)))
 
-        self.dome_model = DomeModel(log=self.log, **self.config.dome)
+        self.dome_model = DomeModel(
+            log=self.log,
+            dome_remote=self.dome_remote,
+            features_to_disable=self.config.features_to_disable,
+            allow_send=self._allow_send,
+            **self.config.dome,
+        )
 
         self.weather_model = WeatherModel(
             log=self.log,
@@ -395,6 +402,7 @@ class EasCsc(salobj.ConfigurableCsc):
             )
 
         self.dome_remote.tel_apertureShutter.callback = self.dome_model.aperture_shutter_callback
+        self.dome_remote.tel_azimuth.callback = self.dome_model.azimuth_callback
         self.dome_remote.tel_louvers.callback = self.dome_model.louvers_callback
         self.ess_ts1_remote.tel_temperature.callback = self.glass_temperature_model.temperature_callback
         self.ess_ts2_remote.tel_temperature.callback = self.glass_temperature_model.temperature_callback
@@ -419,6 +427,7 @@ class EasCsc(salobj.ConfigurableCsc):
             )
 
         self.dome_remote.tel_apertureShutter.callback = None
+        self.dome_remote.tel_azimuth.callback = None
         self.ess_ts1_remote.tel_temperature.callback = None
         self.ess_ts2_remote.tel_temperature.callback = None
         self.ess_ts3_remote.tel_temperature.callback = None
@@ -437,6 +446,7 @@ class EasCsc(salobj.ConfigurableCsc):
         disconnects of the remotes, as well as any other form of
         recoverable failure.
         """
+        assert self.dome_model is not None, "Dome Model not initialized."
         assert self.hvac_model is not None, "HVAC Model not initialized."
         assert self.tma_model is not None, "TMA Model not initialized."
         assert self.diurnal_timer is not None, "Timer not initialized."
@@ -452,6 +462,7 @@ class EasCsc(salobj.ConfigurableCsc):
                     self.weather_model.monitor,
                     self.hvac_model.monitor,
                     self.tma_model.monitor,
+                    self.dome_model.monitor,
                 )
             ]
 
@@ -461,6 +472,7 @@ class EasCsc(salobj.ConfigurableCsc):
                 self.weather_model.monitor_start_event.wait(),
                 self.hvac_model.monitor_start_event.wait(),
                 self.tma_model.monitor_start_event.wait(),
+                self.dome_model.monitor_start_event.wait(),
             )
             self.log.debug("Monitors started.")
             self.monitor_start_event.set()

--- a/python/lsst/ts/eas/weather_model.py
+++ b/python/lsst/ts/eas/weather_model.py
@@ -240,7 +240,11 @@ additionalProperties: false
             return self.last_twilight_temperature
 
         of_date = Time.now()
-        efd_client = lsst_efd_client.EfdClient(self.efd_name)
+        try:
+            efd_client = lsst_efd_client.EfdClient(self.efd_name)
+        except Exception:
+            return None
+
         for days_ago in range(DAYS_TO_SEARCH_FOR_TWILIGHT_TEMPERATURE):
             # Get time of twilight of interest.
             of_date -= DAY

--- a/tests/test_dome.py
+++ b/tests/test_dome.py
@@ -23,10 +23,67 @@ import asyncio
 import logging
 import unittest
 from types import SimpleNamespace
+from typing import Any
+from unittest import mock
 
-from lsst.ts import eas, utils
+from lsst.ts import eas, salobj, utils
+from lsst.ts.eas.cmdwrapper import close_command_tasks
+from lsst.ts.xml.tables.mtdome import find_louver
 
 STD_SLEEP = 0.2
+
+
+class FakeEvtSummaryState:
+    def __init__(self) -> None:
+        self._msg: SimpleNamespace | None = None
+
+    def set_state(self, state: salobj.State | None) -> None:
+        self._msg = None if state is None else SimpleNamespace(summaryState=state)
+
+    def get(self) -> SimpleNamespace | None:
+        return self._msg
+
+
+class FakeDomeLouverCommand:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.topic_info = SimpleNamespace(attr_name="cmd_setLouvers")
+
+    async def set_start(self, **kwargs: Any) -> None:
+        filtered = {k: v for k, v in kwargs.items() if k != "timeout"}
+        self.calls.append(filtered)
+
+
+class FakeDomeRemote:
+    def __init__(self) -> None:
+        self.evt_summaryState = FakeEvtSummaryState()
+        self.salinfo = SimpleNamespace(name="MTDome", index=None)
+        self.cmd_setLouvers = FakeDomeLouverCommand()
+
+
+async def spin_until(pred: Any, *, timeout: float = 5.0, step: float = 0.01) -> None:
+    """Poll `pred()` until true or raise TimeoutError.
+
+    Parameters
+    ----------
+    pred : callable
+        A predicate to test. When it returns True, the polling stops.
+    timeout : `float`
+        Maximum time (seconds) to wait before raising `TimeoutError`.
+    step : `float`
+        Seconds to sleep between successive polls of the predicate.
+
+    Raises
+    ------
+    `TimeoutError`
+        If the predicate is not satisfied before the timeout elapses.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(step)
+    raise TimeoutError("Condition not met before timeout")
 
 
 def get_open_shutter_telemetry() -> SimpleNamespace:
@@ -62,15 +119,34 @@ def get_closed_louver_telemetry() -> SimpleNamespace:
     )
 
 
+def get_commanded_louver_telemetry() -> SimpleNamespace:
+    """Returns louver telemetry with all louvers actively commanded open."""
+    return SimpleNamespace(
+        private_sndStamp=utils.current_tai(),
+        positionActual=[100.0] * 34,
+        positionCommanded=[100.0] * 34,
+    )
+
+
 class TestDomeModel(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
+        self.fake_remote = FakeDomeRemote()
         self.model = eas.dome_model.DomeModel(
             log=logging.getLogger(),
             dome_open_threshold=50.0,
+            louver_sun_angle=60.0,
+            louver_exposed_command=50.0,
+            louver_shaded_command=100.0,
+            sun_altitude_threshold=0.0,
+            dome_remote=self.fake_remote,
+            features_to_disable=[],
         )
         # Always start with dome closed.
         await self.model.aperture_shutter_callback(get_closed_shutter_telemetry())
         await self.model.louvers_callback(get_closed_louver_telemetry())
+
+    async def asyncTearDown(self) -> None:
+        await close_command_tasks(self.model)
 
     async def test_cancel_pending_events_sets_events(self) -> None:
         event = asyncio.Event()
@@ -147,3 +223,136 @@ class TestDomeModel(unittest.IsolatedAsyncioTestCase):
         await self.model.louvers_callback(get_closed_louver_telemetry())
 
         self.assertIsNone(self.model.is_closed)
+
+    async def test_azimuth_callback_updates_dome_azimuth(self) -> None:
+        """azimuth_callback should update dome_azimuth from positionActual."""
+        self.model.features_to_disable = ["day_louvers"]
+        self.assertIsNone(self.model.dome_azimuth)
+
+        await self.model.azimuth_callback(SimpleNamespace(positionActual=123.45))
+
+        self.assertAlmostEqual(self.model.dome_azimuth, 123.45)
+
+    async def test_azimuth_callback_triggers_louver_adjustment(self) -> None:
+        """azimuth_callback triggers louver update on first reading and on
+        azimuth changes greater than `AZIMUTH_CHANGE_THRESHOLD`, but not on
+        sub-threshold changes.
+        """
+        mock_altaz = mock.MagicMock()
+        mock_altaz.alt.deg = 45.0
+        mock_altaz.az.deg = 90.0
+        mock_sun = mock.MagicMock()
+        mock_sun.transform_to.return_value = mock_altaz
+
+        self.model.louvers_telemetry = SimpleNamespace(positionCommanded=[100.0] * 34)
+        self.fake_remote.evt_summaryState.set_state(salobj.State.ENABLED)
+
+        with mock.patch("lsst.ts.eas.dome_model.get_sun", return_value=mock_sun):
+            await self.model.azimuth_callback(SimpleNamespace(positionActual=10.0))
+            await asyncio.sleep(STD_SLEEP)
+            initial = len(self.fake_remote.cmd_setLouvers.calls)
+            self.assertGreaterEqual(initial, 1)
+
+            await self.model.azimuth_callback(SimpleNamespace(positionActual=10.05))
+            await asyncio.sleep(STD_SLEEP)
+            self.assertEqual(len(self.fake_remote.cmd_setLouvers.calls), initial)
+
+            await self.model.azimuth_callback(SimpleNamespace(positionActual=10.5))
+            await asyncio.sleep(STD_SLEEP)
+            self.assertGreater(len(self.fake_remote.cmd_setLouvers.calls), initial)
+
+    async def test_set_louvers_does_not_send_when_not_enabled(self) -> None:
+        """set_louvers should not send if the remote has never been ENABLED."""
+        self.fake_remote.evt_summaryState.set_state(None)
+
+        position = [50.0] * 34
+        await self.model.set_louvers(position=position)
+        await asyncio.sleep(STD_SLEEP)
+
+        self.assertEqual(self.fake_remote.cmd_setLouvers.calls, [])
+
+    async def test_monitor_calls_adjust_louvers_when_sun_is_up(self) -> None:
+        """monitor() adjusts louvers based on sun azimuth.
+
+        With dome at azimuth 0 (slit pointing north) and sun at azimuth 90
+        (east), with louver_sun_angle=60:
+        - Louver A1 (index 0) is uncommanded (positionCommanded=-1) => -1
+        - Louvers A2-E3 (indices 1-13) face the sun (panel normals are
+          53.1-120.75 deg, within 60 deg of az 90) => exposed (50.0)
+        - Louvers F1-N2 (indices 14-33) face away from the sun (panel
+          normals 180-306.9 deg, outside the 60 deg window) => shaded (100.0)
+        """
+        mock_altaz = mock.MagicMock()
+        mock_altaz.alt.deg = 45.0
+        mock_altaz.az.deg = 90.0
+        mock_sun = mock.MagicMock()
+        mock_sun.transform_to.return_value = mock_altaz
+
+        self.model.dome_azimuth = 0.0
+        self.model.louvers_telemetry = SimpleNamespace(
+            positionCommanded=[-1.0] + [100.0] * 33,
+        )
+        self.fake_remote.evt_summaryState.set_state(salobj.State.ENABLED)
+
+        with (
+            mock.patch("lsst.ts.eas.dome_model.DORMANT_TIME", 0.01),
+            mock.patch("lsst.ts.eas.dome_model.get_sun", return_value=mock_sun),
+        ):
+            monitor_task = asyncio.create_task(self.model.monitor())
+            await spin_until(lambda: bool(self.fake_remote.cmd_setLouvers.calls))
+            monitor_task.cancel()
+            try:
+                await monitor_task
+            except asyncio.CancelledError:
+                pass
+
+        position = self.fake_remote.cmd_setLouvers.calls[-1]["position"]
+        self.assertEqual(position[0], -1.0)
+        self.assertTrue(all(p == 50.0 for p in position[1:14]))
+        self.assertTrue(all(p == 100.0 for p in position[14:]))
+
+    async def test_adjust_louvers_dome_opposite_sun_exposes_f1(self) -> None:
+        """Geometric sanity check: when the slit points opposite the sun,
+        the F panel (dome-local offset 180 deg) faces the sun directly,
+        so F1 must be commanded to ``louver_exposed_command``.
+        """
+        sun_az = 73.0
+        self.model.dome_azimuth = (sun_az + 180.0) % 360.0
+        self.model.louvers_telemetry = SimpleNamespace(
+            positionCommanded=[100.0] * 34,
+        )
+        self.fake_remote.evt_summaryState.set_state(salobj.State.ENABLED)
+
+        await self.model.adjust_louvers(sun_az)
+        await spin_until(lambda: bool(self.fake_remote.cmd_setLouvers.calls))
+
+        position = self.fake_remote.cmd_setLouvers.calls[-1]["position"]
+        f1_index = find_louver("F1").index
+        self.assertEqual(
+            position[f1_index],
+            self.model.louver_exposed_command,
+            "F1 should be exposed when the dome slit points opposite the sun",
+        )
+
+    async def test_monitor_skips_adjust_louvers_when_sun_is_down(self) -> None:
+        """monitor() should not call adjust_louvers after sundown."""
+        mock_altaz = mock.MagicMock()
+        mock_altaz.alt.deg = -10.0
+        mock_sun = mock.MagicMock()
+        mock_sun.transform_to.return_value = mock_altaz
+
+        self.model.adjust_louvers = mock.AsyncMock()
+
+        with (
+            mock.patch("lsst.ts.eas.dome_model.DORMANT_TIME", 0.01),
+            mock.patch("lsst.ts.eas.dome_model.get_sun", return_value=mock_sun),
+        ):
+            monitor_task = asyncio.create_task(self.model.monitor())
+            await asyncio.sleep(STD_SLEEP)
+            monitor_task.cancel()
+            try:
+                await monitor_task
+            except asyncio.CancelledError:
+                pass
+
+        self.model.adjust_louvers.assert_not_called()

--- a/tests/test_eas_csc.py
+++ b/tests/test_eas_csc.py
@@ -40,6 +40,7 @@ from lsst.ts.xml.enums.HVAC import DeviceId
 STD_TIMEOUT = 60
 STD_SLEEP = 5
 LONG_SLEEP = 15
+SPIN_SLEEP = 0.1
 
 TEST_CONFIG_DIR = pathlib.Path(__file__).parents[1].joinpath("tests", "config")
 TEST_WIND_DATA_DIR = pathlib.Path(__file__).parent
@@ -129,6 +130,8 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             DeviceId.airExtractionFan04Dome: asyncio.Event(),
         }
 
+        self.set_louvers_calls: list[list[float]] = []
+
         self.mtdome = salobj.Controller("MTDome")
         self.hvac = salobj.Controller("HVAC")
         self.ess = salobj.Controller("ESS", 301)
@@ -157,6 +160,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
         self.hvac.cmd_enableDevice.callback = self.enable_callback
         self.hvac.cmd_disableDevice.callback = self.disable_callback
+        self.mtdome.cmd_setLouvers.callback = self.set_louvers_callback
 
         try:
             yield
@@ -225,6 +229,10 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 self.vec04_state = False
 
         self.hvac_events[message.device_id].set()
+
+    async def set_louvers_callback(self, message: salobj.topics.BaseTopic.DataType) -> None:
+        """Callback for MTDome.cmd_setLouvers."""
+        self.set_louvers_calls.append(list(message.position))
 
     async def wait_for_all_hvac_events(self) -> None:
         await asyncio.wait_for(
@@ -670,3 +678,42 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ahu3_state, True)
         self.assertEqual(self.ahu4_state, True)
         self.assertEqual(self.vec04_state, False)
+
+    async def test_louvers_commanded_when_sun_is_up(self) -> None:
+        """cmd_setLouvers should be sent when the sun is above the horizon."""
+        louver_positions = [50.0] * 34
+        mock_altaz = mock.MagicMock()
+        mock_altaz.alt.deg = 45.0
+        mock_altaz.az.deg = 180.0
+        mock_sun = mock.MagicMock()
+        mock_sun.transform_to.return_value = mock_altaz
+
+        with (
+            mock.patch("lsst.ts.eas.dome_model.DORMANT_TIME", 1.0),
+            mock.patch("lsst.ts.eas.dome_model.get_sun", return_value=mock_sun),
+        ):
+            async with (
+                self.mock_extra_cscs(),
+                self.make_csc(
+                    initial_state=salobj.State.ENABLED,
+                    config_dir=TEST_CONFIG_DIR,
+                    simulation_mode=1,
+                ),
+            ):
+                await asyncio.wait_for(self.csc.monitor_start_event.wait(), timeout=STD_TIMEOUT)
+
+                await self.mtdome.evt_summaryState.set_write(summaryState=salobj.State.ENABLED)
+                await self.mtdome.tel_azimuth.set_write(positionActual=0.0)
+                await self.mtdome.tel_louvers.set_write(
+                    positionActual=louver_positions,
+                    positionCommanded=louver_positions,
+                )
+
+                async def wait_for_louvers() -> None:
+                    while not self.set_louvers_calls:
+                        await asyncio.sleep(SPIN_SLEEP)
+
+                await asyncio.wait_for(wait_for_louvers(), timeout=STD_TIMEOUT)
+                await self.csc.close_tasks()
+
+        self.assertTrue(len(self.set_louvers_calls) > 0)


### PR DESCRIPTION
Add daytime control of dome louvers based on sun position. While the sun is above the horizon, EAS periodically commands each louver to either an "exposed" or "shaded" percent-open setpoint depending on whether the louver faces the sun within the `lover_sun_angle` parameter. Only louvers that have been opened by the operator are controlled, the others are ignored.

 - New `DomeModel.monitor` loop (every `DORMANT_TIME = 300 s`): computes sun alt/az and, while the sun is up, issues `MTDome.cmd_setLouvers`. Louvers reported as uncommanded (`tel_louvers.positionCommanded[i] <= 0`) pass through as `-1` so they are not moved.
 - New `LOUVER_OFFSET` table giving the per-louver azimuthal offset relative to the dome reference, obtained from schematics perpared by John Andrew.
 - Config additions: `dome.louver_sun_angle`, `dome.louver_exposed_command`, `dome.louver_shaded_command`, plus a `day_louvers` entry in `features_to_disable` to skip the adjustment loop entirely.
