### PR TITLE
OSW-2237: Add configurable closed_at_night setpoint cadence, rename closedatnite, drop unused glycol_forecast_active flag.

### DIFF
--- a/doc/news/OSW-2237.misc.rst
+++ b/doc/news/OSW-2237.misc.rst
@@ -1,0 +1,1 @@
+Renamed ``closedatnite`` configuration items to ``closed_at_night``.

--- a/doc/news/OSW-2265.feature.rst
+++ b/doc/news/OSW-2265.feature.rst
@@ -1,0 +1,1 @@
+Added a configurable setpoint cadence for nighttime closed-dome operation in HVAC and TMA.

--- a/doc/news/OSW-2274.misc.rst
+++ b/doc/news/OSW-2274.misc.rst
@@ -1,0 +1,1 @@
+Removed the unused ``glycol_forecast_active`` flag from ``HvacModel``. It was a leftover from when the weather forecast was expected to apply glycol setpoints; that behavior was later removed but the flag remained.

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             * `glycol_chillers`: Glycol chillers will not be controlled in HVAC.
             * `fanspeed`: MTM1M3TS fans will not be controlled.
             * `m1m3ts`: MTM1M3TS setpoints will not be applied.
-            * `closedatnite`: Nighttime closed-dome setpoint control will not run.
+            * `closed_at_night`: Nighttime closed-dome setpoint control will not run.
             * `require_dome_open`: functionality will operate even when the dome is closed.
             * `day_louvers`: louver positions will not be adjusted based on sun position during the day.
         type: array
@@ -74,7 +74,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             - glycol_chillers
             - fanspeed
             - m1m3ts
-            - closedatnite
+            - closed_at_night
             - require_dome_open
             - day_louvers
       twilight_definition:

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -63,10 +63,14 @@ class HvacModel:
         The offset that will be added to the measured temperature in
         selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
         measured in °C.
-    ahu_setpoint_delta_closedatnite : `float`
+    ahu_setpoint_delta_closed_at_night : `float`
         The offset that will be added to the measured temperature in
         selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
         during nighttime closed-dome operation, measured in °C.
+    closed_at_night_setpoint_cadence : `float`, optional
+        Cadence (s) at which the nighttime closed-dome AHU setpoint is
+        reassessed. If ``None``, falls back to the default monitor sleep
+        time (``HVAC_SLEEP_TIME``).
     ahu_control : `list`[`int`]
         The AHU numbers that EAS is allowed to control. Values correspond
         to AHUs 1 through 4.
@@ -125,7 +129,7 @@ class HvacModel:
         weatherforecast_model: WeatherForecastModel,
         hvac_remote: salobj.Remote,
         ahu_setpoint_delta: float,
-        ahu_setpoint_delta_closedatnite: float,
+        ahu_setpoint_delta_closed_at_night: float,
         ahu_control: list[int],
         setpoint_lower_limit: float,
         wind_threshold: float,
@@ -139,6 +143,7 @@ class HvacModel:
         glycol_absolute_maximum: float,
         features_to_disable: list[str],
         forecast_ahu_setpoint_delta: float | None = None,
+        closed_at_night_setpoint_cadence: float | None = None,
         allow_send: Callable[[], bool] | None = None,
     ) -> None:
         self.log = log
@@ -154,7 +159,12 @@ class HvacModel:
         self.weather_model = weather_model
         self.weatherforecast_model = weatherforecast_model
         self.ahu_setpoint_delta = ahu_setpoint_delta
-        self.ahu_setpoint_delta_closedatnite = ahu_setpoint_delta_closedatnite
+        self.ahu_setpoint_delta_closed_at_night = ahu_setpoint_delta_closed_at_night
+        self.closed_at_night_setpoint_cadence = (
+            closed_at_night_setpoint_cadence
+            if closed_at_night_setpoint_cadence is not None
+            else HVAC_SLEEP_TIME
+        )
         self.ahu_control = ahu_control
         self.setpoint_lower_limit = setpoint_lower_limit
         self.wind_threshold = wind_threshold
@@ -179,11 +189,6 @@ class HvacModel:
         # Glycol setpoints
         self.glycol_setpoint1: float | None = None
         self.glycol_setpoint2: float | None = None
-
-        # When True, a forecast-driven setpoint is active and
-        # monitor_glycol_chillers should apply it rather than recomputing
-        # from the current indoor temperature. Cleared at twilight.
-        self.glycol_forecast_active: bool = False
 
         # The remote
         self.hvac_remote = hvac_remote
@@ -214,7 +219,7 @@ properties:
       The offset that will be applied to the measured temperature in
       selecting a setpoint for the HVAC air handling units (AHUs/UMAs)
       measured in °C.
-  ahu_setpoint_delta_closedatnite:
+  ahu_setpoint_delta_closed_at_night:
     type: number
     default: -1.0
     description: >-
@@ -283,6 +288,13 @@ properties:
     description: >-
       AHU setpoint offset (°C) used when driven by forecast. If absent,
       ahu_setpoint_delta is used.
+  closed_at_night_setpoint_cadence:
+    type: [number, "null"]
+    default: null
+    exclusiveMinimum: 0
+    description: >-
+      Cadence (s) at which the nighttime closed-dome AHU setpoint is
+      reassessed. If absent, the default monitor sleep time is used.
 required:
   - ahu_setpoint_delta
   - setpoint_lower_limit
@@ -463,7 +475,6 @@ additionalProperties: false
             return
         self.weatherforecast_model.remove_callback(self.twilight_forecast_callback_id)
         self.twilight_forecast_callback_id = None
-        self.glycol_forecast_active = False
 
     def set_twilight_forecast_callback(self) -> None:
         self.clear_twilight_forecast_callback()
@@ -638,28 +649,23 @@ additionalProperties: false
                     await asyncio.sleep(HVAC_SLEEP_TIME)
                     continue
 
-                if not self.glycol_forecast_active:
-                    # After the setpoints are chosen at noon, monitor
-                    # the system and adjust setpoints if needed.
-                    ambient_temperature = self.weather_model.current_indoor_temperature
-                    if ambient_temperature is not None and not self.check_glycol_setpoint(
-                        ambient_temperature
-                    ):
-                        self.log.debug("Recomputing glycol setpoints.")
-                        glycol_setpoint1, glycol_setpoint2 = self.compute_glycol_setpoints(
-                            ambient_temperature
-                        )
+                # After the setpoints are chosen at noon, monitor
+                # the system and adjust setpoints if needed.
+                ambient_temperature = self.weather_model.current_indoor_temperature
+                if ambient_temperature is not None and not self.check_glycol_setpoint(ambient_temperature):
+                    self.log.debug("Recomputing glycol setpoints.")
+                    glycol_setpoint1, glycol_setpoint2 = self.compute_glycol_setpoints(ambient_temperature)
 
-                        if all(
-                            (
-                                glycol_setpoint1 is not None,
-                                not math.isnan(glycol_setpoint1),
-                                glycol_setpoint2 is not None,
-                                not math.isnan(glycol_setpoint2),
-                            )
-                        ):
-                            self.glycol_setpoint1 = glycol_setpoint1
-                            self.glycol_setpoint2 = glycol_setpoint2
+                    if all(
+                        (
+                            glycol_setpoint1 is not None,
+                            not math.isnan(glycol_setpoint1),
+                            glycol_setpoint2 is not None,
+                            not math.isnan(glycol_setpoint2),
+                        )
+                    ):
+                        self.glycol_setpoint1 = glycol_setpoint1
+                        self.glycol_setpoint2 = glycol_setpoint2
 
                 chiller_commands = []
                 if self.glycol_setpoint1 is not None:
@@ -735,17 +741,17 @@ additionalProperties: false
         warned_no_temperature = False
 
         while self.diurnal_timer.is_running:
-            if "closedatnite" in self.features_to_disable:
-                await asyncio.sleep(HVAC_SLEEP_TIME)
+            if "closed_at_night" in self.features_to_disable:
+                await asyncio.sleep(self.closed_at_night_setpoint_cadence)
                 continue
 
             if self.diurnal_timer.is_night(Time.now()) and self.dome_model.is_closed:
                 if "room_setpoint" in self.features_to_disable:
-                    await asyncio.sleep(HVAC_SLEEP_TIME)
+                    await asyncio.sleep(self.closed_at_night_setpoint_cadence)
                     continue
 
                 setpoint = max(
-                    self.weather_model.current_temperature + self.ahu_setpoint_delta_closedatnite,
+                    self.weather_model.current_temperature + self.ahu_setpoint_delta_closed_at_night,
                     self.setpoint_lower_limit,
                 )
                 if math.isnan(setpoint):
@@ -768,4 +774,4 @@ additionalProperties: false
                         ]
                     )
 
-            await asyncio.sleep(HVAC_SLEEP_TIME)
+            await asyncio.sleep(self.closed_at_night_setpoint_cadence)

--- a/python/lsst/ts/eas/tma_model.py
+++ b/python/lsst/ts/eas/tma_model.py
@@ -80,15 +80,19 @@ class TmaModel:
     top_end_setpoint_delta : `float`
         The difference between the indoor (ESS:112) temperature and the
         setpoint to apply for the top end, via MTMount.setThermal.
-    m1m3_extra_delta_closedatnite : `float`
+    m1m3_extra_delta_closed_at_night : `float`
         Extra temperature offset (°C) applied during nighttime closed-dome
         operation on top of the configured glycol and heater setpoint deltas.
-    top_end_setpoint_delta_closedatnite : `float`
+    top_end_setpoint_delta_closed_at_night : `float`
         The difference between the indoor temperature and the top-end
         setpoint during nighttime closed-dome operation.
     m1m3_setpoint_cadence : `float`
         The cadence at which applySetpoints commands should be sent to
         MTM1M3TS (seconds).
+    closed_at_night_setpoint_cadence : `float`, optional
+        Cadence (s) at which the nighttime closed-dome M1M3TS and top-end
+        setpoints are reassessed. If ``None``, falls back to
+        ``m1m3_setpoint_cadence``.
     m1m3ts_delay_mode : `dict`
         Configuration for the delay controller policy after dome opening.
     setpoint_deadband_heating : `float`
@@ -134,8 +138,8 @@ class TmaModel:
         glycol_setpoint_delta: float,
         heater_setpoint_delta: float,
         top_end_setpoint_delta: float,
-        m1m3_extra_delta_closedatnite: float,
-        top_end_setpoint_delta_closedatnite: float,
+        m1m3_extra_delta_closed_at_night: float,
+        top_end_setpoint_delta_closed_at_night: float,
         m1m3_setpoint_cadence: float,
         m1m3ts_delay_mode: dict,
         setpoint_deadband_heating: float,
@@ -148,6 +152,7 @@ class TmaModel:
         forecast_glycol_setpoint_delta: float | None = None,
         forecast_heater_setpoint_delta: float | None = None,
         forecast_top_end_setpoint_delta: float | None = None,
+        closed_at_night_setpoint_cadence: float | None = None,
         allow_send: Callable[[], bool] | None = None,
     ) -> None:
         self.log = log
@@ -187,9 +192,14 @@ class TmaModel:
             if forecast_top_end_setpoint_delta is not None
             else top_end_setpoint_delta
         )
-        self.m1m3_extra_delta_closedatnite = m1m3_extra_delta_closedatnite
-        self.top_end_setpoint_delta_closedatnite = top_end_setpoint_delta_closedatnite
+        self.m1m3_extra_delta_closed_at_night = m1m3_extra_delta_closed_at_night
+        self.top_end_setpoint_delta_closed_at_night = top_end_setpoint_delta_closed_at_night
         self.m1m3_setpoint_cadence = m1m3_setpoint_cadence
+        self.closed_at_night_setpoint_cadence = (
+            closed_at_night_setpoint_cadence
+            if closed_at_night_setpoint_cadence is not None
+            else m1m3_setpoint_cadence
+        )
         self.m1m3ts_delay_mode = m1m3ts_delay_mode
         self.setpoint_deadband_heating = setpoint_deadband_heating
         self.setpoint_deadband_cooling = setpoint_deadband_cooling
@@ -247,13 +257,13 @@ properties:
     description: Difference (°C) between the ambient temperature and MTMount thermal setpoint.
     type: number
     default: -1.0
-  m1m3_extra_delta_closedatnite:
+  m1m3_extra_delta_closed_at_night:
     description: >-
       Additional difference (°C) applied during nighttime closed-dome operation
       on top of the configured M1M3TS glycol and heater setpoint deltas.
     type: number
     default: 0.0
-  top_end_setpoint_delta_closedatnite:
+  top_end_setpoint_delta_closed_at_night:
     description: >-
       Difference (°C) between the ambient temperature and MTMount thermal setpoint
       during nighttime closed-dome operation.
@@ -263,6 +273,13 @@ properties:
     description: Time (s) between successive assessments of the TMA setpoint.
     type: number
     default: 300.0
+  closed_at_night_setpoint_cadence:
+    description: >-
+      Cadence (s) at which the nighttime closed-dome M1M3TS and top-end
+      setpoints are reassessed. If absent, m1m3_setpoint_cadence is used.
+    type: [number, "null"]
+    default: null
+    exclusiveMinimum: 0
   m1m3ts_delay_mode:
     description: Behavior after dome opening before resuming M1M3TS ambient tracking.
     type: object
@@ -397,8 +414,8 @@ required:
   - glycol_setpoint_delta
   - heater_setpoint_delta
   - top_end_setpoint_delta
-  - m1m3_extra_delta_closedatnite
-  - top_end_setpoint_delta_closedatnite
+  - m1m3_extra_delta_closed_at_night
+  - top_end_setpoint_delta_closed_at_night
   - m1m3_setpoint_cadence
   - m1m3ts_delay_mode
   - setpoint_deadband_heating
@@ -734,7 +751,6 @@ additionalProperties: false
             async with self.diurnal_timer.sunrise_condition:
                 await self.diurnal_timer.sunrise_condition.wait()
 
-                # Avoid stepping on setpoints from the closedatnite coroutine.
                 await asyncio.sleep(self.m1m3_setpoint_cadence)
 
                 last_twilight_temperature = await self.weather_model.get_last_twilight_temperature()
@@ -768,8 +784,11 @@ additionalProperties: false
             # Otherwise, there would be a conflict between this coroutine
             # and the one that controls the setpoints based on an indoor
             # temperature.
-            if "closedatnite" in self.features_to_disable or "require_dome_open" in self.features_to_disable:
-                await asyncio.sleep(self.m1m3_setpoint_cadence)
+            if (
+                "closed_at_night" in self.features_to_disable
+                or "require_dome_open" in self.features_to_disable
+            ):
+                await asyncio.sleep(self.closed_at_night_setpoint_cadence)
                 continue
 
             if self.diurnal_timer.is_night(Time.now()) and self.dome_model.is_closed:
@@ -783,18 +802,18 @@ additionalProperties: false
                     warned_no_temperature = False
                     await self.apply_setpoints(
                         outdoor_temperature,
-                        delta_adjustment=self.m1m3_extra_delta_closedatnite,
+                        delta_adjustment=self.m1m3_extra_delta_closed_at_night,
                     )
 
                     if "top_end" not in self.features_to_disable:
                         await self.send_set_thermal(
                             top_end_chiller_setpoint=(
-                                outdoor_temperature + self.top_end_setpoint_delta_closedatnite
+                                outdoor_temperature + self.top_end_setpoint_delta_closed_at_night
                             ),
                             top_end_chiller_state=ThermalCommandState.ON,
                         )
 
-            await asyncio.sleep(self.m1m3_setpoint_cadence)
+            await asyncio.sleep(self.closed_at_night_setpoint_cadence)
 
     def clear_twilight_forecast_callback(self) -> None:
         if self.twilight_forecast_callback_id is None:

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -29,6 +29,7 @@ from types import SimpleNamespace
 from typing import NotRequired, TypedDict
 
 import astropy
+import jsonschema
 import yaml
 from astropy.time import Time, TimeDelta
 
@@ -212,7 +213,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     def make_model(self, **overrides: float | list[int] | list[str] | None) -> hvac_model.HvacModel:
         params = dict(
             ahu_setpoint_delta=0.0,
-            ahu_setpoint_delta_closedatnite=0.0,
+            ahu_setpoint_delta_closed_at_night=0.0,
             ahu_control=[1, 2, 3, 4],
             setpoint_lower_limit=6.0,
             wind_threshold=10.0,
@@ -701,7 +702,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             night: bool
             closed: bool
             ahu_setpoint_delta: NotRequired[float]
-            ahu_setpoint_delta_closedatnite: NotRequired[float]
+            ahu_setpoint_delta_closed_at_night: NotRequired[float]
             temp: float
             expect_setpoints: dict[str, float]
 
@@ -727,7 +728,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 "closed": True,
                 "temp": 9.0,
                 "ahu_setpoint_delta": 0.0,
-                "ahu_setpoint_delta_closedatnite": -1.5,
+                "ahu_setpoint_delta_closed_at_night": -1.5,
                 "expect_setpoints": {
                     ahu: 7.5
                     for ahu in (
@@ -770,7 +771,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
                 model = self.make_model(
                     ahu_setpoint_delta=case.get("ahu_setpoint_delta", 0.0),
-                    ahu_setpoint_delta_closedatnite=case.get("ahu_setpoint_delta_closedatnite", 0.0),
+                    ahu_setpoint_delta_closed_at_night=case.get("ahu_setpoint_delta_closed_at_night", 0.0),
                 )
                 task = asyncio.create_task(model.apply_setpoint_at_night())
 
@@ -793,6 +794,33 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             with self.subTest(config_path=filename):
                 validated = validator.validate(vars(self.get_config(filename)))
                 self.assertEqual(validated["ahu_control"], expected_ahu_control)
+
+    def test_closed_at_night_setpoint_cadence(self) -> None:
+        """Schema and constructor handling of closed_at_night cadence."""
+        validator = salobj.DefaultingValidator(hvac_model.HvacModel.get_config_schema())
+        base_config = vars(self.get_config("hvac_ahu_control_default.yaml"))
+
+        # Missing -> default null in the validated dict.
+        validated = validator.validate(dict(base_config))
+        self.assertIsNone(validated["closed_at_night_setpoint_cadence"])
+
+        # A positive number is accepted.
+        validated = validator.validate({**base_config, "closed_at_night_setpoint_cadence": 30.0})
+        self.assertEqual(validated["closed_at_night_setpoint_cadence"], 30.0)
+
+        # exclusiveMinimum: 0 rejects zero and negative values.
+        for bad_value in (0, -1.0):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaises(jsonschema.exceptions.ValidationError):
+                    validator.validate({**base_config, "closed_at_night_setpoint_cadence": bad_value})
+
+        # Constructor: omitted/None falls back to HVAC_SLEEP_TIME;
+        # explicit value is used as-is.
+        default_model = self.make_model()
+        self.assertEqual(default_model.closed_at_night_setpoint_cadence, hvac_model.HVAC_SLEEP_TIME)
+
+        override_model = self.make_model(closed_at_night_setpoint_cadence=42.0)
+        self.assertEqual(override_model.closed_at_night_setpoint_cadence, 42.0)
 
     async def test_forecast_ahu_applies_setpoint(self) -> None:
         """Forecast-based AHU setpoints should be applied."""

--- a/tests/test_tma.py
+++ b/tests/test_tma.py
@@ -27,6 +27,8 @@ import unittest
 from collections import deque
 from types import SimpleNamespace
 
+import jsonschema
+
 from lsst.ts import eas, salobj
 from lsst.ts.eas.weatherforecast_model import WeatherForecastModel
 
@@ -142,9 +144,9 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=model_args["glycol_setpoint_delta"],
                 heater_setpoint_delta=model_args["heater_setpoint_delta"],
                 top_end_setpoint_delta=model_args["top_end_setpoint_delta"],
-                m1m3_extra_delta_closedatnite=model_args.get("m1m3_extra_delta_closedatnite", 0.0),
-                top_end_setpoint_delta_closedatnite=model_args.get(
-                    "top_end_setpoint_delta_closedatnite",
+                m1m3_extra_delta_closed_at_night=model_args.get("m1m3_extra_delta_closed_at_night", 0.0),
+                top_end_setpoint_delta_closed_at_night=model_args.get(
+                    "top_end_setpoint_delta_closed_at_night",
                     model_args["top_end_setpoint_delta"],
                 ),
                 m1m3_setpoint_cadence=cadence,
@@ -244,8 +246,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         glycol_setpoint_delta = -2.0
         heater_setpoint_delta = -1.0
         top_end_setpoint_delta = -0.5
-        m1m3_extra_delta_closedatnite = 0.5
-        top_end_setpoint_delta_closedatnite = -1.5
+        m1m3_extra_delta_closed_at_night = 0.5
+        top_end_setpoint_delta_closed_at_night = -1.5
 
         for case in scenarios:
             with self.subTest(case=case["name"]):
@@ -257,19 +259,19 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                     glycol_setpoint_delta=glycol_setpoint_delta,
                     heater_setpoint_delta=heater_setpoint_delta,
                     top_end_setpoint_delta=top_end_setpoint_delta,
-                    m1m3_extra_delta_closedatnite=m1m3_extra_delta_closedatnite,
-                    top_end_setpoint_delta_closedatnite=top_end_setpoint_delta_closedatnite,
+                    m1m3_extra_delta_closed_at_night=m1m3_extra_delta_closed_at_night,
+                    top_end_setpoint_delta_closed_at_night=top_end_setpoint_delta_closed_at_night,
                     features_to_disable=[],
                 )
 
                 if case["expect_m1m3"]:
                     self.assertEqual(
                         glycol_setpoint,
-                        case["indoor_temperature"] + glycol_setpoint_delta + m1m3_extra_delta_closedatnite,
+                        case["indoor_temperature"] + glycol_setpoint_delta + m1m3_extra_delta_closed_at_night,
                     )
                     self.assertEqual(
                         heater_setpoint,
-                        case["indoor_temperature"] + heater_setpoint_delta + m1m3_extra_delta_closedatnite,
+                        case["indoor_temperature"] + heater_setpoint_delta + m1m3_extra_delta_closed_at_night,
                     )
                 else:
                     self.assertIsNone(glycol_setpoint)
@@ -278,7 +280,7 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 if case["expect_top_end"]:
                     self.assertEqual(
                         top_end_setpoint,
-                        case["indoor_temperature"] + top_end_setpoint_delta_closedatnite,
+                        case["indoor_temperature"] + top_end_setpoint_delta_closed_at_night,
                     )
                 else:
                     self.assertIsNone(top_end_setpoint)
@@ -427,8 +429,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2,
                 heater_setpoint_delta=heater_setpoint_delta,
                 top_end_setpoint_delta=-1,
-                m1m3_extra_delta_closedatnite=0.0,
-                top_end_setpoint_delta_closedatnite=-1,
+                m1m3_extra_delta_closed_at_night=0.0,
+                top_end_setpoint_delta_closed_at_night=-1,
                 m1m3_setpoint_cadence=10,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -517,8 +519,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2.0,
                 heater_setpoint_delta=-1.0,
                 top_end_setpoint_delta=-1.0,
-                m1m3_extra_delta_closedatnite=0.0,
-                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_extra_delta_closed_at_night=0.0,
+                top_end_setpoint_delta_closed_at_night=-1.0,
                 m1m3_setpoint_cadence=10,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -574,8 +576,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2.0,
                 heater_setpoint_delta=-1.0,
                 top_end_setpoint_delta=-1.0,
-                m1m3_extra_delta_closedatnite=0.0,
-                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_extra_delta_closed_at_night=0.0,
+                top_end_setpoint_delta_closed_at_night=-1.0,
                 m1m3_setpoint_cadence=10,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -637,8 +639,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2.0,
                 heater_setpoint_delta=-1.0,
                 top_end_setpoint_delta=-1.0,
-                m1m3_extra_delta_closedatnite=0.0,
-                top_end_setpoint_delta_closedatnite=-1.0,
+                m1m3_extra_delta_closed_at_night=0.0,
+                top_end_setpoint_delta_closed_at_night=-1.0,
                 m1m3_setpoint_cadence=10,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -698,8 +700,8 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 glycol_setpoint_delta=-2,
                 heater_setpoint_delta=0.0,
                 top_end_setpoint_delta=-1,
-                m1m3_extra_delta_closedatnite=0.0,
-                top_end_setpoint_delta_closedatnite=-1,
+                m1m3_extra_delta_closed_at_night=0.0,
+                top_end_setpoint_delta_closed_at_night=-1,
                 m1m3_setpoint_cadence=cadence,
                 setpoint_deadband_heating=0,
                 setpoint_deadband_cooling=0,
@@ -754,6 +756,32 @@ class TestTma(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             done, pending = await asyncio.wait({task}, timeout=STD_TIMEOUT)
             if pending:
                 self.fail("follow_ess_indoor did not stop before timeout")
+
+    def test_closed_at_night_setpoint_cadence_schema(self) -> None:
+        """closed_at_night_setpoint_cadence setting affects cadence."""
+        validator = salobj.DefaultingValidator(eas.tma_model.TmaModel.get_config_schema())
+        base_config: dict[str, typing.Any] = {
+            "m1m3ts_delay_mode": {"mode": "time_delay", "delay": 0.0},
+            "fan_speed": {
+                "fan_speed_min": 700.0,
+                "fan_speed_max": 2000.0,
+                "fan_glycol_heater_offset_min": -1.0,
+                "fan_glycol_heater_offset_max": -4.0,
+                "fan_throttle_turn_on_temp_diff": 0.0,
+                "fan_throttle_max_temp_diff": 1.0,
+            },
+        }
+
+        validated = validator.validate(dict(base_config))
+        self.assertIsNone(validated["closed_at_night_setpoint_cadence"])
+
+        validated = validator.validate({**base_config, "closed_at_night_setpoint_cadence": 30.0})
+        self.assertEqual(validated["closed_at_night_setpoint_cadence"], 30.0)
+
+        for bad_value in (0, -1.0):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaises(jsonschema.exceptions.ValidationError):
+                    validator.validate({**base_config, "closed_at_night_setpoint_cadence": bad_value})
 
     def basic_make_csc(
         self,


### PR DESCRIPTION
This PR handles several small tasks for EAS:
* Makes the cadence for "closed at night" setpoints configurable.
* Removes the unused `glycol_forecast_active` flag in HvacModel.
* Changes "closedatnite" to "closed_at_night" in the configuration item names.

It will be necessary to migrate the changes in ts_config_ocs at the same time, and EAS live on the summit will need to switch to a branch to avoid compatibility breaks. A PR has been set up in ts_config_ocs. Currently summit is using v0.28.61 with modifications.

The Jira tickets covered by this PR are:
* OSW-2237 rename closedatnite to closed_at_night
* OSW-2265 closed at night setpoint cadence configuration item
* OSW-2274 remove unused `glycol_forecast_active` flag