### PR TITLE
OSW-2348: Add frequency control via configFan when enabling VEC-04.

### DIFF
--- a/doc/news/OSW-2348.bugfix.rst
+++ b/doc/news/OSW-2348.bugfix.rst
@@ -1,0 +1,1 @@
+Added frequency control via configFan when enabling VEC-04.

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -83,6 +83,8 @@ class HvacModel:
     vec04_hold_time : `float`
         Minimum time to wait before changing the state of the VEC-04 fan. This
         value is ignored if the dome is opened or closed. (s)
+    vec04_fan_frequency : `float`
+        Rotation frequency commanded to the VEC-04 fan when it is enabled (Hz).
     glycol_band_low : `float`
         The lower bound (more negative) of the allowed difference between the
         average glycol setpoint and the ambient temperature (°C). This
@@ -134,6 +136,7 @@ class HvacModel:
         setpoint_lower_limit: float,
         wind_threshold: float,
         vec04_hold_time: float,
+        vec04_fan_frequency: float,
         glycol_band_low: float,
         glycol_band_high: float,
         glycol_average_offset: float,
@@ -169,6 +172,7 @@ class HvacModel:
         self.setpoint_lower_limit = setpoint_lower_limit
         self.wind_threshold = wind_threshold
         self.vec04_hold_time = vec04_hold_time
+        self.vec04_fan_frequency = vec04_fan_frequency
         self.features_to_disable = features_to_disable
 
         # Forecast-specific delta overrides
@@ -254,6 +258,11 @@ properties:
     description: >-
       Minimum time to wait before changing the state of the VEC-04 fan. This
       value is ignored if the dome is opened or closed (s).
+  vec04_fan_frequency:
+    type: number
+    default: 55.0
+    description: >-
+      Rotation frequency commanded to the VEC-04 fan when it is enabled (Hz).
   glycol_band_low:
     type: number
     default: -10.0
@@ -335,6 +344,10 @@ additionalProperties: false
             return None
         return commands
 
+    @command_wrapper(remote_attr="hvac_remote", command_attr="cmd_configFan")
+    async def config_fan(self, frequency: float) -> dict[str, Any]:
+        return {"device_id": DeviceId.airExtractionFan04Dome, "frequency": frequency}
+
     async def monitor(self) -> None:
         """Monitor the dome status and windspeed to control the HVAC.
 
@@ -408,6 +421,7 @@ additionalProperties: false
                     self.last_vec04_time = utils.current_tai()
                     if wind_threshold:
                         self.log.info(f"Turning on VEC-04 fan! {change_message}")
+                        await self.config_fan(self.vec04_fan_frequency)
                         enable_device_list.append(DeviceId.airExtractionFan04Dome)
                     else:
                         self.log.info(f"Turning off VEC-04 fan! {change_message}")

--- a/tests/test_eas_csc.py
+++ b/tests/test_eas_csc.py
@@ -160,6 +160,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
         self.hvac.cmd_enableDevice.callback = self.enable_callback
         self.hvac.cmd_disableDevice.callback = self.disable_callback
+        self.hvac.cmd_configFan.callback = self.fan_callback
         self.mtdome.cmd_setLouvers.callback = self.set_louvers_callback
 
         try:
@@ -212,6 +213,10 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 self.vec04_state = True
 
         self.hvac_events[message.device_id].set()
+
+    async def fan_callback(self, message: salobj.topics.BaseTopic.DataType) -> None:
+        """Callback for HVAC.cmd_configFan."""
+        self.log.info(f"fan_callback {message.device_id=} {message.frequency=}")
 
     async def disable_callback(self, message: salobj.topics.BaseTopic.DataType) -> None:
         """Callback for HVAC.cmd_disableDevice."""
@@ -650,6 +655,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
             self.hvac.cmd_enableDevice.callback = self.enable_callback
             self.hvac.cmd_disableDevice.callback = self.disable_callback
+            self.hvac.cmd_configFan.callback = self.fan_callback
 
             await asyncio.wait_for(
                 asyncio.gather(

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -152,6 +152,7 @@ class HvacMock(salobj.BaseCsc):
         self.disable_called: set[int] = set()
         self.chiller_setpoints: dict[int, float] = dict()  # Calls to configChiller
         self.ahu_setpoints: dict[int, float] = dict()  # Calls to configLowerAhu
+        self.fan_frequencies: dict[int, float] = dict()  # Calls to configFan
 
     async def do_enableDevice(self, data: salobj.BaseMsgType) -> None:
         self.enable_called.add(data.device_id)
@@ -164,6 +165,9 @@ class HvacMock(salobj.BaseCsc):
 
     async def do_configChiller(self, data: salobj.BaseMsgType) -> None:
         self.chiller_setpoints[data.device_id] = data.activeSetpoint
+
+    async def do_configFan(self, data: salobj.BaseMsgType) -> None:
+        self.fan_frequencies[data.device_id] = data.frequency
 
 
 class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
@@ -218,6 +222,7 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             setpoint_lower_limit=6.0,
             wind_threshold=10.0,
             vec04_hold_time=0.0,
+            vec04_fan_frequency=55.0,
             glycol_band_low=-10.0,
             glycol_band_high=-5.0,
             glycol_average_offset=-7.5,
@@ -462,9 +467,13 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         except asyncio.CancelledError:
             pass  # expected
 
-        # VEC-04 was enabled
+        # VEC-04 was enabled and its frequency was configured
         self.assertIn(DeviceId.airExtractionFan04Dome, self.hvac.enable_called)
         self.assertNotIn(DeviceId.airExtractionFan04Dome, self.hvac.disable_called)
+        self.assertEqual(
+            self.hvac.fan_frequencies.get(DeviceId.airExtractionFan04Dome),
+            55.0,
+        )
 
         for ahu in (
             DeviceId.airHandlingUnit01Dome,
@@ -491,6 +500,10 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(STD_SLEEP)
         self.assertIn(DeviceId.airExtractionFan04Dome, self.hvac.enable_called)
         self.assertNotIn(DeviceId.airExtractionFan04Dome, self.hvac.disable_called)
+        self.assertEqual(
+            self.hvac.fan_frequencies.get(DeviceId.airExtractionFan04Dome),
+            55.0,
+        )
 
         # Wind rises above threshold --> should disable VEC-04
         self.weather.average_windspeed = 12.0


### PR DESCRIPTION
This change adds control of the VEC-04 fan frequency via `configFan`. Currently a fixed (configurable) frequency is applied whenever the fan is turned on, defaulting to 55 Hz. No command is applied to set the fan frequency when it is turned off.