### PR TITLE
Add one last louver command to be issued after sundown to restore to the observer-commanded positions.

### DIFF
--- a/doc/news/OSW-2643.bugfix.rst
+++ b/doc/news/OSW-2643.bugfix.rst
@@ -1,0 +1,1 @@
+Added one last louver command to be issued after sundown to restore to the observer-commanded positions.

--- a/python/lsst/ts/eas/dome_model.py
+++ b/python/lsst/ts/eas/dome_model.py
@@ -377,9 +377,10 @@ additionalProperties: false
         Computes the sun's current altitude and azimuth at the observatory
         location and, if the sun is above `sun_altitude_threshold` and the
         ``day_louvers`` feature is not disabled, calls `adjust_louvers`
-        with the sun azimuth. When the sun is below the threshold, the tracked
-        observer baseline is cleared so the next daytime adjustment re-adopts
-        fresh observer commands rather than re-applying the previous day's.
+        with the sun azimuth. At sundown (the first update with the sun below
+        the threshold) each louver the observer opened is commanded to its
+        observer-commanded position one last time and the cached observer-
+        commanded position is cleared.
         """
         if "day_louvers" in self.features_to_disable:
             return
@@ -395,8 +396,11 @@ additionalProperties: false
         )
         if altaz.alt.deg > self.sun_altitude_threshold:
             await self.adjust_louvers(altaz.az.deg)
-        else:
-            # Sundown: discard the stale observer baseline.
+        elif self.louver_operator_command is not None:
+            # Sundown: the daytime cap no longer applies, so open each louver
+            # the observer opened to its commanded position one last time (the
+            # loop will not run again until sunrise), then discard the cache.
+            await self.set_louvers(self.louver_operator_command)
             self.louver_operator_command = None
             self.louver_eas_command = None
 

--- a/tests/test_dome.py
+++ b/tests/test_dome.py
@@ -490,6 +490,31 @@ class TestDomeModel(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(self.model.louver_operator_command)
         self.assertIsNone(self.model.louver_eas_command)
 
+    async def test_update_louvers_for_sun_opens_to_operator_command_at_sundown(self) -> None:
+        """At sundown each opened louver is restored to the observer command.
+
+        A sun-facing louver may have been capped below the observer's command
+        during the day. Since the daytime logic does not run again until
+        sunrise, the observer baseline is commanded one last time at sundown so
+        louvers the observer opened are not left capped overnight. Louvers the
+        observer did not open (<= 0) stay uncommanded (-1).
+        """
+        self.model.louver_operator_command = [-1.0] + [100.0] * 33
+        self.fake_remote.evt_summaryState.set_state(salobj.State.ENABLED)
+
+        mock_altaz = mock.MagicMock()
+        mock_altaz.alt.deg = -10.0
+        mock_sun = mock.MagicMock()
+        mock_sun.transform_to.return_value = mock_altaz
+
+        with mock.patch("lsst.ts.eas.dome_model.get_sun", return_value=mock_sun):
+            await self.model.update_louvers_for_sun()
+        await spin_until(lambda: bool(self.fake_remote.cmd_setLouvers.calls))
+
+        position = self.fake_remote.cmd_setLouvers.calls[-1]["position"]
+        self.assertEqual(position[0], -1.0)
+        self.assertTrue(all(p == 100.0 for p in position[1:]))
+
     async def test_monitor_skips_adjust_louvers_when_sun_is_down(self) -> None:
         """monitor() should not call adjust_louvers after sundown."""
         mock_altaz = mock.MagicMock()


### PR DESCRIPTION
A small change to ensure that the observer commanded positions are re-instated after sunset.