### PR TITLE
Add catchup for HVAC when one or more AHUs is disabled.

### DIFF
--- a/doc/news/OSW-1891.feature.rst
+++ b/doc/news/OSW-1891.feature.rst
@@ -1,0 +1,1 @@
+Added catchup for HVAC when one or more AHUs is disabled.

--- a/python/lsst/ts/eas/config_schema.py
+++ b/python/lsst/ts/eas/config_schema.py
@@ -60,6 +60,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             * `closed_at_night`: Nighttime closed-dome setpoint control will not run.
             * `require_dome_open`: functionality will operate even when the dome is closed.
             * `day_louvers`: louver positions will not be adjusted based on sun position during the day.
+            * `ahu_off_catchup`: daytime AHU catch-up regulation (for when AHUs are turned off) will not run.
         type: array
         items:
           type: string
@@ -77,6 +78,7 @@ CONFIG_SCHEMA = yaml.safe_load(
             - closed_at_night
             - require_dome_open
             - day_louvers
+            - ahu_off_catchup
       twilight_definition:
         description: >
           Definition of twilight. Can be a number (in degrees) between -90 and 0, corresponding

--- a/python/lsst/ts/eas/eas_csc.py
+++ b/python/lsst/ts/eas/eas_csc.py
@@ -22,6 +22,7 @@
 __all__ = ["EasCsc", "run_eas"]
 
 import asyncio
+import functools
 import math
 import typing
 from types import SimpleNamespace
@@ -165,7 +166,13 @@ class EasCsc(salobj.ConfigurableCsc):
         self.hvac_remote = salobj.Remote(
             domain=self.domain,
             name="HVAC",
-            include=["summaryState"],
+            include=[
+                "summaryState",
+                "airHandlingUnit01Dome",
+                "airHandlingUnit02Dome",
+                "airHandlingUnit03Dome",
+                "airHandlingUnit04Dome",
+            ],
         )
         self.weatherforecast_remote = salobj.Remote(
             domain=self.domain,
@@ -392,6 +399,7 @@ class EasCsc(salobj.ConfigurableCsc):
         assert self.glass_temperature_model is not None, "Glass model not initialized."
         assert self.weather_model is not None, "Weather Model not initialized."
         assert self.weatherforecast_model is not None, "WeatherForecast model not initialized."
+        assert self.hvac_model is not None, "HVAC Model not initialized."
 
         if self.ess_indoor_remote is None or self.ess_outdoor_remote is None:
             raise RuntimeError(
@@ -416,6 +424,21 @@ class EasCsc(salobj.ConfigurableCsc):
             self.weatherforecast_model.hourly_trend_callback
         )
 
+        # A single callback handles all four AHU telemetry topics; the AHU
+        # number is bound per-topic so the model knows which unit reported.
+        self.hvac_remote.tel_airHandlingUnit01Dome.callback = functools.partial(
+            self.hvac_model.ahu_working_state_callback, 1
+        )
+        self.hvac_remote.tel_airHandlingUnit02Dome.callback = functools.partial(
+            self.hvac_model.ahu_working_state_callback, 2
+        )
+        self.hvac_remote.tel_airHandlingUnit03Dome.callback = functools.partial(
+            self.hvac_model.ahu_working_state_callback, 3
+        )
+        self.hvac_remote.tel_airHandlingUnit04Dome.callback = functools.partial(
+            self.hvac_model.ahu_working_state_callback, 4
+        )
+
     def disconnect_callbacks(self) -> None:
         """Disconnects callbacks from their remotes."""
         if self.ess_indoor_remote is None or self.ess_outdoor_remote is None:
@@ -437,6 +460,10 @@ class EasCsc(salobj.ConfigurableCsc):
         self.ess_indoor_remote.tel_dewPoint.callback = None
         self.ess_indoor_remote.tel_temperature.callback = None
         self.weatherforecast_remote.tel_hourlyTrend.callback = None
+        self.hvac_remote.tel_airHandlingUnit01Dome.callback = None
+        self.hvac_remote.tel_airHandlingUnit02Dome.callback = None
+        self.hvac_remote.tel_airHandlingUnit03Dome.callback = None
+        self.hvac_remote.tel_airHandlingUnit04Dome.callback = None
 
     async def monitor_health(self) -> None:
         """Manage the `monitor_dome_shutter` control loop.

--- a/python/lsst/ts/eas/hvac_model.py
+++ b/python/lsst/ts/eas/hvac_model.py
@@ -42,6 +42,7 @@ from .weatherforecast_model import WeatherForecastModel
 HVAC_SLEEP_TIME = 60.0  # How often to check the HVAC state (seconds)
 STD_TIMEOUT = 5  # seconds
 N_CHILLERS = 2  # EAS controls two HVAC glycol chillers.
+N_AHUS = 4  # The HVAC system has four dome air handling units (AHUs/UMAs).
 
 
 class HvacModel:
@@ -74,6 +75,25 @@ class HvacModel:
     ahu_control : `list`[`int`]
         The AHU numbers that EAS is allowed to control. Values correspond
         to AHUs 1 through 4.
+    ahu_off_catchup_deltas : `list`[`float`]
+        Four setpoint deltas (°C) applied to the AHU working setpoint while
+        AHUs are off, indexed by the number of AHUs off minus one (one off uses
+        the first element, ... four off the fourth). The deepest delta reached
+        is held until all four AHUs are back on, then released to zero.
+    ahu_off_catchup_rate : `float`
+        Part of the AHU-off daytime catch-up logic: once all AHUs are back on
+        after some were turned off, this is the amount (°C) by which the
+        daytime AHU setpoint is lowered for each 1 °C the ambient (indoor ESS)
+        temperature exceeds the base setpoint, helping the dome catch up after
+        falling behind while the AHUs were off.
+    ahu_off_catchup_poll_interval : `float`
+        Part of the AHU-off daytime catch-up logic: the cadence (s) at which
+        the ambient-overshoot catch-up (applied once all AHUs are back on) is
+        reassessed.
+    ahu_off_catchup_threshold : `float`
+        Part of the AHU-off daytime catch-up logic: the ambient excess (°C)
+        above the base setpoint above which the ambient-overshoot catch-up
+        (applied once all AHUs are back on) begins.
     setpoint_lower_limit : `float`
         The minimum allowed setpoint for thermal control. If a lower setpoint
         than this is indicated from the ESS temperature readings, this setpoint
@@ -118,6 +138,7 @@ class HvacModel:
          * forecast
          * forecast_ahu
          * glycol_chillers
+         * ahu_off_catchup
         Any other values are ignored.
     """
 
@@ -133,6 +154,10 @@ class HvacModel:
         ahu_setpoint_delta: float,
         ahu_setpoint_delta_closed_at_night: float,
         ahu_control: list[int],
+        ahu_off_catchup_deltas: list[float],
+        ahu_off_catchup_rate: float,
+        ahu_off_catchup_poll_interval: float,
+        ahu_off_catchup_threshold: float,
         setpoint_lower_limit: float,
         wind_threshold: float,
         vec04_hold_time: float,
@@ -157,12 +182,40 @@ class HvacModel:
 
         self.last_vec04_time: float = 0  # Last time VEC-04 was changed (UNIX TAI seconds).
 
+        # Most recent workingState (on/off) telemetry for AHUs 1-4, indexed by
+        # AHU number minus one. None means no telemetry has been received yet
+        # for that AHU.
+        self.ahu_working_states: list[bool | None] = [None] * N_AHUS
+
+        # Cached AHU setpoint, which can be used if catchup is required
+        # because one or more AHUs has been disabled.
+        self.cached_ahu_setpoint: float | None = None
+
+        # Catch-up offset (°C, <= 0) currently applied to the AHU setpoint. It
+        # carries the first stage's hold while AHUs are off (latched to the
+        # deepest level reached, see ahu_working_state_callback) and, once all
+        # AHUs are back on, the second stage's ambient-overshoot lowering (see
+        # apply_ahu_off_catchup). Only one stage owns it at a time. Every
+        # setpoint writer (forecast, sunrise) adds it, so a periodic forecast
+        # refresh re-applies the current catch-up setpoint instead of
+        # overwriting it.
+        self.catchup_delta: float = 0.0
+
+        # The ambient-overshoot catch-up coroutine. It is spawned by
+        # ahu_working_state_callback when all AHUs return to on after one or
+        # more were off, and cancelled when any AHU goes off again.
+        self.ahu_off_catchup_task: asyncio.Task | None = None
+
         # Configuration parameters:
         self.dome_model = dome_model
         self.weather_model = weather_model
         self.weatherforecast_model = weatherforecast_model
         self.ahu_setpoint_delta = ahu_setpoint_delta
         self.ahu_setpoint_delta_closed_at_night = ahu_setpoint_delta_closed_at_night
+        self.ahu_off_catchup_deltas = ahu_off_catchup_deltas
+        self.ahu_off_catchup_rate = ahu_off_catchup_rate
+        self.ahu_off_catchup_poll_interval = ahu_off_catchup_poll_interval
+        self.ahu_off_catchup_threshold = ahu_off_catchup_threshold
         self.closed_at_night_setpoint_cadence = (
             closed_at_night_setpoint_cadence
             if closed_at_night_setpoint_cadence is not None
@@ -208,6 +261,82 @@ class HvacModel:
         """
         return tuple(DeviceId[AHU(ahu).name] for ahu in self.ahu_control)
 
+    async def ahu_working_state_callback(self, ahu: int, data: salobj.BaseMsgType) -> None:
+        """Record the latest workingState for one AHU.
+
+        This single callback is registered for all four
+        ``HVAC.airHandlingUnit0<N>Dome`` telemetry topics. The ``ahu`` argument
+        (bound via :func:`functools.partial` at registration time) identifies
+        which AHU the sample describes, since the telemetry itself carries no
+        unit identifier.
+
+        Parameters
+        ----------
+        ahu : `int`
+            The AHU number (1-4) this telemetry sample is for.
+        data : `~lsst.ts.salobj.BaseMsgType`
+            A newly received airHandlingUnit telemetry item.
+        """
+        # Off-count before recording this sample. Only this AHU's entry changes
+        # per call, so the array still holds the previous state here; this lets
+        # the recovery transition (any number off -> all on) be detected
+        # without caching state across calls.
+        previous_n_off = sum(1 for state in self.ahu_working_states if state is False)
+        self.ahu_working_states[ahu - 1] = bool(data.workingState)
+
+        if "ahu_off_catchup" in self.features_to_disable:
+            return
+
+        # Count AHUs that are explicitly off (None means no telemetry yet, so a
+        # lack of data never triggers a catch-up offset). All four AHUs count,
+        # regardless of whether EAS is configured to control them.
+        n_off = sum(1 for state in self.ahu_working_states if state is False)
+        old_catchup_delta = self.catchup_delta
+
+        if n_off > 0:
+            # One or more AHUs off: the first stage owns catchup_delta. Stop
+            # the second-stage loop and (re)establish the first-stage hold. A
+            # fresh episode starts from the evening target (dropping any
+            # second-stage overshoot); going deeper holds the deepest level
+            # reached until all AHUs are back on.
+            self.cancel_ahu_off_catchup()
+            if previous_n_off == 0:
+                self.catchup_delta = self.ahu_off_catchup_deltas[n_off - 1]
+            else:
+                self.catchup_delta = min(self.catchup_delta, self.ahu_off_catchup_deltas[n_off - 1])
+        elif previous_n_off > 0:
+            # All AHUs just came back on: release the first-stage hold to the
+            # evening target and hand catchup_delta to the second-stage
+            # ambient-overshoot loop.
+            self.catchup_delta = 0.0
+            self.start_ahu_off_catchup()
+        # Otherwise all AHUs remain on and the second-stage loop owns
+        # catchup_delta; leave it untouched so this per-sample callback does
+        # not clobber the value apply_ahu_off_catchup is maintaining.
+
+        # If the offset changed, re-apply the cached setpoint with the new
+        # offset: this lowers the setpoint as AHUs go off and restores it to
+        # the target once they are all back on. Skipped until a base setpoint
+        # is known (e.g. while the dome is open, see control_ahus_and_vec04).
+        if self.catchup_delta != old_catchup_delta and self.cached_ahu_setpoint is not None:
+            self.log.debug(
+                "Apply AHU setpoints [6] catchup_delta=%.2f => %.2f",
+                self.catchup_delta,
+                self.cached_ahu_setpoint + self.catchup_delta,
+            )
+            await self.apply_ahu_setpoints(self.cached_ahu_setpoint + self.catchup_delta)
+
+    def start_ahu_off_catchup(self) -> None:
+        """Spawn the ambient-overshoot catch-up loop if not already running."""
+        if self.ahu_off_catchup_task is None or self.ahu_off_catchup_task.done():
+            self.ahu_off_catchup_task = asyncio.create_task(self.run_ahu_off_catchup())
+
+    def cancel_ahu_off_catchup(self) -> None:
+        """Cancel the ambient-overshoot catch-up loop if it is running."""
+        if self.ahu_off_catchup_task is not None:
+            self.ahu_off_catchup_task.cancel()
+            self.ahu_off_catchup_task = None
+
     @classmethod
     def get_config_schema(cls) -> str:
         return yaml.safe_load(
@@ -241,6 +370,43 @@ properties:
       type: integer
       enum: [1, 2, 3, 4]
     uniqueItems: true
+  ahu_off_catchup_deltas:
+    type: array
+    default: [0.0, -1.0, -2.0, -3.0]
+    description: >-
+      Setpoint deltas (°C) applied to the AHU working setpoint while AHUs are
+      off, to help daytime regulation catch up. The elements are used when one,
+      two, three, and four AHUs are off, respectively. The deepest delta reached
+      is held until all four AHUs are back on, then released to zero. (While all
+      four are off no setpoint is sent, but the fourth element is still held and
+      applied as the AHUs come back.)
+    items:
+      type: number
+    minItems: 4
+    maxItems: 4
+  ahu_off_catchup_rate:
+    type: number
+    default: 1.0
+    description: >-
+      Part of the AHU-off daytime catch-up logic. Once all AHUs are back on
+      after some were turned off, the daytime AHU setpoint is lowered by this
+      amount (°C) for each 1 °C the ambient (indoor ESS) temperature exceeds the
+      base setpoint, down to setpoint_lower_limit.
+  ahu_off_catchup_poll_interval:
+    type: number
+    default: 900.0
+    exclusiveMinimum: 0
+    description: >-
+      Part of the AHU-off daytime catch-up logic. Cadence (s) at which the
+      ambient-overshoot catch-up (applied once all AHUs are back on) is
+      reassessed.
+  ahu_off_catchup_threshold:
+    type: number
+    default: 1.0
+    description: >-
+      Part of the AHU-off daytime catch-up logic. Ambient excess (°C) above the
+      base setpoint above which the ambient-overshoot catch-up (applied once all
+      AHUs are back on) begins.
   setpoint_lower_limit:
     type: number
     default: 6.0
@@ -348,6 +514,35 @@ additionalProperties: false
     async def config_fan(self, frequency: float) -> dict[str, Any]:
         return {"device_id": DeviceId.airExtractionFan04Dome, "frequency": frequency}
 
+    async def apply_ahu_setpoints(self, setpoint: float, respect_lower_limit: bool = True) -> None:
+        """Send a new setpoint to all of the controlled AHUs.
+
+        The configured list of AHUs to be controlled is respected so that
+        only those AHUs are commanded. Additionally, the limit imposed by
+        `setpoint_lower_limit` is enforced.
+
+        Parameters
+        ----------
+        `setpoint` : `float`
+            The desired setpoint. The greater of this temperature or the
+            configured lower limit will be applied to all currently controlled
+            AHUs.
+        """
+        if respect_lower_limit:
+            setpoint = max(setpoint, self.setpoint_lower_limit)
+        await self.config_lower_ahu(
+            [
+                {
+                    "device_id": device_id,
+                    "workingSetpoint": setpoint,
+                    "maxFanSetpoint": math.nan,
+                    "minFanSetpoint": math.nan,
+                    "antiFreezeTemperature": math.nan,
+                }
+                for device_id in self.get_controlled_ahus()
+            ]
+        )
+
     async def monitor(self) -> None:
         """Monitor the dome status and windspeed to control the HVAC.
 
@@ -385,6 +580,7 @@ additionalProperties: false
     async def close(self) -> None:
         """Cancel any in-flight command tasks."""
         self.clear_twilight_forecast_callback()
+        self.cancel_ahu_off_catchup()
         await close_command_tasks(self)
 
     async def control_ahus_and_vec04(self) -> None:
@@ -429,6 +625,14 @@ additionalProperties: false
 
             if shutter_closed != cached_shutter_closed:
                 cached_shutter_closed = shutter_closed
+
+                # Clear the AHU-off catch-up hold on every dome transition:
+                # opening the dome intentionally disables the AHUs, which would
+                # otherwise pollute the latched offset. The cached base
+                # setpoint is kept so it can be re-commanded to the AHUs on a
+                # re-close instead of leaving them at the stale catch-up value.
+                self.catchup_delta = 0.0
+
                 ahus = self.get_controlled_ahus()
                 if shutter_closed:
                     if "ahu" not in self.features_to_disable:
@@ -450,6 +654,13 @@ additionalProperties: false
                 await self.disable_devices(disable_device_list)
             if enable_device_list:
                 await self.enable_devices(enable_device_list)
+            # On a dome re-close the AHUs are re-enabled above; re-command the
+            # current base setpoint now (after the enable, so it is not a no-op
+            # on a still-disabled AHU) so they do not run at the stale catch-up
+            # value they held at dome open until the next forecast refresh.
+            if shutter_closed and enable_device_list and self.cached_ahu_setpoint is not None:
+                self.log.debug("Apply AHU setpoints [1] %.2f", self.cached_ahu_setpoint)
+                await self.apply_ahu_setpoints(self.cached_ahu_setpoint)
             await asyncio.sleep(HVAC_SLEEP_TIME)
 
     async def wait_for_sunrise(self) -> None:
@@ -467,21 +678,16 @@ additionalProperties: false
                 if self.diurnal_timer.is_running and last_twilight_temperature is not None:
                     if "room_setpoint" not in self.features_to_disable:
                         # Time to set the room setpoint based on last twilight
-                        setpoint = max(
-                            last_twilight_temperature + self.ahu_setpoint_delta,
-                            self.setpoint_lower_limit,
+                        self.cached_ahu_setpoint = last_twilight_temperature + self.ahu_setpoint_delta
+                        self.log.debug(
+                            "Apply AHU setpoints [2] "
+                            "last_twilight_temperature=%.2f ahu_setpoint_delta=%.2f => %.2f",
+                            last_twilight_temperature,
+                            self.ahu_setpoint_delta,
+                            self.cached_ahu_setpoint,
                         )
-                        await self.config_lower_ahu(
-                            [
-                                {
-                                    "device_id": device_id,
-                                    "workingSetpoint": setpoint,
-                                    "maxFanSetpoint": math.nan,
-                                    "minFanSetpoint": math.nan,
-                                    "antiFreezeTemperature": math.nan,
-                                }
-                                for device_id in self.get_controlled_ahus()
-                            ]
+                        await self.apply_ahu_setpoints(
+                            last_twilight_temperature + self.ahu_setpoint_delta + self.catchup_delta,
                         )
 
     def clear_twilight_forecast_callback(self) -> None:
@@ -511,21 +717,9 @@ additionalProperties: false
 
     async def apply_forecast_setpoints(self, predicted_temperature: float) -> None:
         if "room_setpoint" not in self.features_to_disable and "forecast_ahu" not in self.features_to_disable:
-            setpoint = max(
-                predicted_temperature + self.forecast_ahu_setpoint_delta,
-                self.setpoint_lower_limit,
-            )
-            await self.config_lower_ahu(
-                [
-                    {
-                        "device_id": device_id,
-                        "workingSetpoint": setpoint,
-                        "maxFanSetpoint": math.nan,
-                        "minFanSetpoint": math.nan,
-                        "antiFreezeTemperature": math.nan,
-                    }
-                    for device_id in self.get_controlled_ahus()
-                ]
+            self.cached_ahu_setpoint = predicted_temperature + self.forecast_ahu_setpoint_delta
+            await self.apply_ahu_setpoints(
+                predicted_temperature + self.forecast_ahu_setpoint_delta + self.catchup_delta
             )
 
     async def monitor_twilight_forecast(self) -> None:
@@ -774,18 +968,92 @@ additionalProperties: false
                         warned_no_temperature = True
 
                 else:
-                    # Apply setpoint for each configured AHU
-                    await self.config_lower_ahu(
-                        [
-                            {
-                                "device_id": device_id,
-                                "workingSetpoint": setpoint,
-                                "maxFanSetpoint": math.nan,
-                                "minFanSetpoint": math.nan,
-                                "antiFreezeTemperature": math.nan,
-                            }
-                            for device_id in self.get_controlled_ahus()
-                        ]
-                    )
+                    # Apply setpoint for each configured AHU. For nighttime
+                    # setpoints, the lower limit is not enforced.
+                    self.log.debug("Apply AHU setpoints [3] %.2f", setpoint)
+                    await self.apply_ahu_setpoints(setpoint, respect_lower_limit=False)
 
             await asyncio.sleep(self.closed_at_night_setpoint_cadence)
+
+    async def apply_ahu_off_catchup(self) -> bool:
+        """Apply one cycle of the ambient-overshoot AHU catch-up.
+
+        This is the second stage of the AHU-off daytime catch-up logic. The
+        first stage (see `ahu_working_state_callback`) lowers the setpoint
+        while AHUs are off. Once all AHUs are back on, this stage keeps
+        lowering the daytime setpoint while the ambient (indoor ESS)
+        temperature is running hotter than the base setpoint, so the dome can
+        recover the heat it gained while the AHUs were down.
+
+        Returns
+        -------
+        should_stop : `bool`
+            True if the catch-up loop should stop: either the overshoot has
+            been corrected, or the regulating context no longer holds (the
+            feature was disabled, it is night, the dome opened, or an AHU went
+            off). False if the caller should keep polling (the base setpoint or
+            the ambient temperature is not yet available).
+        """
+        if (
+            "ahu_off_catchup" in self.features_to_disable
+            or "room_setpoint" in self.features_to_disable
+            or "ahu" in self.features_to_disable
+        ):
+            return True
+
+        # If an AHU is off the first stage owns catchup_delta.
+        if not all(self.ahu_working_states):
+            return True
+
+        # All AHUs are on, so the second stage owns catchup_delta. The catch-up
+        # only runs during the day with the dome closed; once that context is
+        # gone there is nothing to recover, so release the offset and stop.
+        if self.diurnal_timer.is_night(Time.now()) or not self.dome_model.is_closed:
+            self.catchup_delta = 0.0
+            return True
+
+        # Keep polling until the data needed to regulate becomes available.
+        if self.cached_ahu_setpoint is None:
+            return False
+        ambient_temperature = self.weather_model.current_indoor_temperature
+        if math.isnan(ambient_temperature):
+            return False
+
+        base_setpoint = max(self.cached_ahu_setpoint, self.setpoint_lower_limit)
+        excess = ambient_temperature - base_setpoint
+        if excess <= self.ahu_off_catchup_threshold:
+            # Overshoot corrected: release the offset, restore the base
+            # setpoint, and finish.
+            self.catchup_delta = 0.0
+            self.log.debug("Apply AHU setpoints [4] %.2f", base_setpoint)
+            await self.apply_ahu_setpoints(base_setpoint)
+            return True
+
+        # Lower the setpoint and record the offset in catchup_delta, so the
+        # forecast/sunrise setpoint writers re-apply this lowered value on
+        # their next refresh.
+        self.catchup_delta = -self.ahu_off_catchup_rate * excess
+        self.log.debug(
+            "Apply AHU setpoints [5] catchup_delta=%.2f => %.2f", self.catchup_delta, base_setpoint
+        )
+        await self.apply_ahu_setpoints(base_setpoint + self.catchup_delta)
+        return False
+
+    async def run_ahu_off_catchup(self) -> None:
+        """Reassess the ambient-overshoot catch-up.
+
+        Spawned by `ahu_working_state_callback` when all AHUs return to on
+        after one or more were off. Applies :meth:`apply_ahu_off_catchup` once
+        immediately and then every ``ahu_off_catchup_poll_interval``
+        seconds, exiting when that method reports the catch-up is complete or
+        its context is gone (the callback also cancels it directly when an AHU
+        goes off).
+        """
+        self.log.debug("run_ahu_off_catchup")
+        while self.diurnal_timer.is_running:
+            try:
+                if await self.apply_ahu_off_catchup():
+                    break
+            except Exception:
+                self.log.exception("In AHU-off daytime catch-up loop")
+            await asyncio.sleep(self.ahu_off_catchup_poll_interval)

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -214,11 +214,17 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         )
         self.weatherforecast = WeatherForecastModel(log=self.log)
 
-    def make_model(self, **overrides: float | list[int] | list[str] | None) -> hvac_model.HvacModel:
+    def make_model(
+        self, **overrides: float | list[int] | list[float] | list[str] | None
+    ) -> hvac_model.HvacModel:
         params = dict(
             ahu_setpoint_delta=0.0,
             ahu_setpoint_delta_closed_at_night=0.0,
             ahu_control=[1, 2, 3, 4],
+            ahu_off_catchup_deltas=[0.0, -1.0, -2.0, -3.0],
+            ahu_off_catchup_rate=1.0,
+            ahu_off_catchup_poll_interval=900.0,
+            ahu_off_catchup_threshold=1.0,
             setpoint_lower_limit=6.0,
             wind_threshold=10.0,
             vec04_hold_time=0.0,
@@ -558,6 +564,48 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         ):
             # AHUs enabled on close
             self.assertIn(ahu, self.hvac.enable_called)
+
+    async def test_dome_transition_clears_hold_retains_setpoint(self) -> None:
+        """A dome open/close transition should clear the catch-up hold."""
+        hvac_model.HVAC_SLEEP_TIME = STD_SLEEP
+        self.dome.is_closed = False
+        self.weather.average_windspeed = 3.0
+
+        model = self.make_model()
+        task = asyncio.create_task(model.control_ahus_and_vec04())
+
+        # Let the loop settle into the dome-open state.
+        await asyncio.sleep(STD_SLEEP)
+
+        # Simulate a stale, latched daytime catch-up state.
+        model.cached_ahu_setpoint = 10.0
+        model.catchup_delta = -3.0
+
+        # Close the dome: the transition should reset the catch-up state.
+        self.dome.is_closed = True
+        await asyncio.sleep(STD_SLEEP)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected
+
+        # The catch-up hold is cleared, but the base setpoint is retained so it
+        # can be re-commanded to the AHUs on the re-close.
+        self.assertEqual(model.cached_ahu_setpoint, 10.0)
+        self.assertEqual(model.catchup_delta, 0.0)
+
+        # And the AHUs are enabled on close, and the base setpoint is
+        # re-commanded to them immediately (not deferred to the next forecast).
+        for ahu in (
+            DeviceId.airHandlingUnit01Dome,
+            DeviceId.airHandlingUnit02Dome,
+            DeviceId.airHandlingUnit03Dome,
+            DeviceId.airHandlingUnit04Dome,
+        ):
+            self.assertIn(ahu, self.hvac.enable_called)
+            self.assertEqual(self.hvac.ahu_setpoints.get(ahu), 10.0)
 
     async def test_ahu_control_limits_shutter_commands(self) -> None:
         """Only configured AHUs should be enabled and disabled."""
@@ -946,6 +994,239 @@ class TestHvac(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         await asyncio.wait_for(task, timeout=STD_TIMEOUT)
 
         self.hvac.ahu_setpoints.clear()
+
+    async def test_disabled_ahus_change_delta(self) -> None:
+        """Each number of AHUs off selects the matching catch-up delta."""
+        deltas = [0.0, -1.0, -2.0, -3.0]
+
+        # Index i is the expected delta when i AHUs are off (0 AHUs off -> 0).
+        expected_by_n_off = [0.0] + deltas
+        for n_off, expected in enumerate(expected_by_n_off):
+            model = self.make_model(ahu_off_catchup_deltas=deltas)
+            # Turn the first n_off AHUs off; the rest report on.
+            for ahu in range(1, 5):
+                working_state = ahu > n_off
+                await model.ahu_working_state_callback(ahu, types.SimpleNamespace(workingState=working_state))
+            self.assertEqual(model.catchup_delta, expected)
+
+    async def test_catchup_delta_latches_until_all_on(self) -> None:
+        """The catch-up delta holds until every AHU is back on, and the
+        setpoint is re-applied whenever the delta changes."""
+        model = self.make_model(ahu_off_catchup_deltas=[0.0, -1.0, -2.0, -3.0])
+
+        # A base setpoint must be known for the callback to re-apply setpoints
+        # (normally set by sunrise/forecast). Record the setpoints applied
+        # instead of commanding the AHUs, so the catch-up behavior is visible.
+        base_setpoint = 10.0
+        model.cached_ahu_setpoint = base_setpoint
+        applied_setpoints: list[float] = []
+
+        async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+            applied_setpoints.append(setpoint)
+
+        model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+
+        async def set_ahu(ahu: int, on: bool) -> None:
+            await model.ahu_working_state_callback(ahu, types.SimpleNamespace(workingState=on))
+
+        # All four AHUs start on: no offset, nothing applied.
+        for ahu in range(1, 5):
+            await set_ahu(ahu, True)
+        self.assertEqual(model.catchup_delta, 0.0)
+        self.assertEqual(applied_setpoints, [])
+
+        # Three AHUs go off: hold the three-off delta and lower the setpoint as
+        # the delta deepens (one-off is a zero delta, so no setpoint yet).
+        await set_ahu(1, False)
+        await set_ahu(2, False)
+        await set_ahu(3, False)
+        self.assertEqual(model.catchup_delta, -2.0)
+        self.assertEqual(applied_setpoints, [base_setpoint - 1.0, base_setpoint - 2.0])
+
+        # Two come back (one still off): the delta is held, not relaxed, so no
+        # new setpoint is applied.
+        await set_ahu(1, True)
+        await set_ahu(2, True)
+        self.assertEqual(model.catchup_delta, -2.0)
+        self.assertEqual(applied_setpoints, [base_setpoint - 1.0, base_setpoint - 2.0])
+
+        # All four off deepens the held delta even after partial recovery, and
+        # lowers the setpoint further.
+        await set_ahu(1, False)
+        await set_ahu(2, False)
+        await set_ahu(4, False)
+        self.assertEqual(model.catchup_delta, -3.0)
+        self.assertEqual(
+            applied_setpoints,
+            [base_setpoint - 1.0, base_setpoint - 2.0, base_setpoint - 3.0],
+        )
+
+        # Everything comes back on: the hold releases and the base setpoint is
+        # restored.
+        for ahu in range(1, 5):
+            await set_ahu(ahu, True)
+        self.assertEqual(model.catchup_delta, 0.0)
+        self.assertEqual(
+            applied_setpoints,
+            [base_setpoint - 1.0, base_setpoint - 2.0, base_setpoint - 3.0, base_setpoint],
+        )
+
+        # Recovery also spawns the ambient-overshoot catch-up loop; cancel it
+        # so it does not linger past the test.
+        model.cancel_ahu_off_catchup()
+
+    async def test_ahu_off_catchup_lowers_setpoint_on_overshoot(self) -> None:
+        for rate, expected in ((1.0, 7.0), (0.5, 8.5)):
+            with self.subTest(rate=rate):
+                model = self.make_model(ahu_off_catchup_rate=rate, ahu_off_catchup_threshold=1.0)
+                model.cached_ahu_setpoint = 10.0
+                model.ahu_working_states = [True, True, True, True]
+                self.weather.current_indoor_temperature = 13.0  # excess of 3 °C
+
+                applied: list[float] = []
+
+                async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+                    applied.append(setpoint)
+
+                model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+
+                stop = await model.apply_ahu_off_catchup()
+
+                # Still overshooting, so the loop should continue.
+                self.assertFalse(stop)
+                self.assertEqual(applied, [expected])
+
+    async def test_ahu_off_catchup_completes_within_threshold(self) -> None:
+        """Once ambient is within the threshold, the base setpoint is restored
+        and the loop reports completion."""
+        model = self.make_model(ahu_off_catchup_rate=1.0, ahu_off_catchup_threshold=1.0)
+        model.cached_ahu_setpoint = 10.0
+        model.ahu_working_states = [True, True, True, True]
+        self.weather.current_indoor_temperature = 10.5  # excess of 0.5 °C (<= threshold)
+
+        applied: list[float] = []
+
+        async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+            applied.append(setpoint)
+
+        model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+
+        stop = await model.apply_ahu_off_catchup()
+
+        self.assertTrue(stop)
+        self.assertEqual(applied, [10.0])
+
+    async def test_ahu_off_catchup_clamps_to_lower_limit(self) -> None:
+        """The catch-up setpoint never drops below setpoint_lower_limit."""
+        model = self.make_model(
+            ahu_off_catchup_rate=1.0,
+            ahu_off_catchup_threshold=1.0,
+            setpoint_lower_limit=6.0,
+        )
+        model.cached_ahu_setpoint = 7.0
+        model.ahu_working_states = [True, True, True, True]
+        self.weather.current_indoor_temperature = 20.0  # large overshoot
+
+        self.hvac.ahu_setpoints.clear()
+        stop = await model.apply_ahu_off_catchup()
+        await asyncio.sleep(STD_SLEEP)  # let the command task reach the mock
+
+        self.assertFalse(stop)
+        for ahu in (
+            DeviceId.airHandlingUnit01Dome,
+            DeviceId.airHandlingUnit02Dome,
+            DeviceId.airHandlingUnit03Dome,
+            DeviceId.airHandlingUnit04Dome,
+        ):
+            self.assertEqual(self.hvac.ahu_setpoints[ahu], 6.0)
+        self.hvac.ahu_setpoints.clear()
+
+    async def test_ahu_off_catchup_stops_when_context_gone(self) -> None:
+        """The catch-up reports completion (and sends nothing) when its
+        regulating context no longer holds."""
+        applied: list[float] = []
+
+        async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+            applied.append(setpoint)
+
+        # (case name, is night, dome closed, fourth AHU on, features disabled)
+        cases: list[tuple[str, bool, bool, bool, list[str]]] = [
+            ("night", True, True, True, []),
+            ("dome_open", False, False, True, []),
+            ("ahu_off", False, True, False, []),
+            ("disabled", False, True, True, ["ahu_off_catchup"]),
+        ]
+        for name, night, dome_closed, fourth_on, features in cases:
+            with self.subTest(case=name):
+                model = self.make_model(features_to_disable=features)
+                model.cached_ahu_setpoint = 10.0
+                model.ahu_working_states = [True, True, True, fourth_on]
+                self.diurnal._night = night
+                self.dome.is_closed = dome_closed
+                self.weather.current_indoor_temperature = 20.0
+                applied.clear()
+                model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+
+                stop = await model.apply_ahu_off_catchup()
+
+                self.assertTrue(stop)
+                self.assertEqual(applied, [])
+
+    async def test_ahu_off_catchup_waits_for_data(self) -> None:
+        """Missing base setpoint or ambient temperature keeps the loop polling
+        without sending a command."""
+
+        async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+            raise AssertionError("No setpoint should be sent while data is missing.")
+
+        # No base setpoint yet.
+        model = self.make_model()
+        model.ahu_working_states = [True, True, True, True]
+        model.cached_ahu_setpoint = None
+        model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+        self.assertFalse(await model.apply_ahu_off_catchup())
+
+        # Base setpoint known but ambient temperature unavailable.
+        model.cached_ahu_setpoint = 10.0
+        self.weather.current_indoor_temperature = math.nan
+        self.assertFalse(await model.apply_ahu_off_catchup())
+
+    async def test_recovery_manages_catchup_task(self) -> None:
+        """Recovery (all AHUs back on after any number were off) spawns the
+        catch-up loop, and an AHU going off again cancels it."""
+        model = self.make_model(ahu_off_catchup_deltas=[0.0, -1.0, -2.0, -3.0])
+        model.cached_ahu_setpoint = 10.0
+
+        async def record(setpoint: float, respect_lower_limit: bool = True) -> None:
+            pass
+
+        model.apply_ahu_setpoints = record  # type: ignore[method-assign]
+
+        async def set_ahu(ahu: int, on: bool) -> None:
+            await model.ahu_working_state_callback(ahu, types.SimpleNamespace(workingState=on))
+
+        # All AHUs on from the start: no recovery, so no catch-up task.
+        for ahu in range(1, 5):
+            await set_ahu(ahu, True)
+        self.assertIsNone(model.ahu_off_catchup_task)
+
+        # A single AHU goes off: still no overshoot task (stage one owns the
+        # setpoint). One off uses a zero delta, so this also confirms the
+        # trigger does not depend on a non-zero catch-up having been held.
+        await set_ahu(1, False)
+        self.assertIsNone(model.ahu_off_catchup_task)
+
+        # Back on: AHU recovery spawns the overshoot task.
+        await set_ahu(1, True)
+        task = model.ahu_off_catchup_task
+        self.assertIsNotNone(task)
+
+        # An AHU goes off again: the task is cancelled and cleared.
+        await set_ahu(3, False)
+        self.assertIsNone(model.ahu_off_catchup_task)
+        await asyncio.sleep(0)  # let the cancellation settle
+        assert task is not None
+        self.assertTrue(task.cancelled())
 
     def basic_make_csc(
         self,


### PR DESCRIPTION
When one or more AHUs are turned off, the dome loses cooling capacity and drifts warmer than its setpoint. This PR adds catch-up rules so EAS lowers the AHU working setpoint to help the dome recover once cooling is available again.
 * EasCsc now subscribes to the four HVAC.airHandlingUnit0<N>Dome telemetry topics. A single ahu_working_state_callback (bound per-AHU via functools.partial) tracks which units are on/off.
 * A delta is applied to the AHU working setpoint when one or more AHUs is disabled. Afterward, a delta is applied based on the difference between the indoor temperature and the desired setpoint, until the discrepancy disappears.
 * Configuration items are added:
   - `ahu_off_catchup_deltas` the delta to applied based on the number of disabled AHUs, defaults to [0.0, -1.0, -2.0, -3.0]
   - `ahu_off_catchup_rate` amount the setpoint is lowered per 1°C ambient overshoot, default 1.0
   - `ahu_off_catchup_poll_interval` cadence of monitoring the catchup in seconds, default 900.0
   - `ahu_off_catchup_threshold` the threshold at which catchup mode is activated after AHUs are disabled